### PR TITLE
Update __init__.py

### DIFF
--- a/homeassistant_bring_api/__init__.py
+++ b/homeassistant_bring_api/__init__.py
@@ -1,0 +1,1 @@
+from .bring import Bring


### PR DESCRIPTION
allows easier import of module

```
from homeassistant_bring_api import Bring
bring = Bring(...)
```

and

```
import homeassistant_bring_api
bring = homeassistant_bring_api.Bring(...)
```

should also work now