### PR TITLE
Change base url

### DIFF
--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -260,6 +260,8 @@ class Bring:
         list
             The JSON response as a list. A list of item details.
             Caution: This is NOT a list of the items currently marked as 'to buy'. See getItems() for that.
+            This contains the items that where customized by changing their default icon, category or uploading
+            an image.
 
         Raises
         ------

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -32,7 +32,7 @@ class Bring:
         self.uuid = ""
         self.publicUuid = ""
 
-        self.url = "https://api.getbring.com/rest/v2/"
+        self.url = "https://api.getbring.com/rest/"
 
         self.headers = {
             "Authorization": "Bearer",
@@ -83,7 +83,7 @@ class Bring:
         data = {"email": self.mail, "password": self.password}
 
         try:
-            url = f"{self.url}bringauth"
+            url = f"{self.url}v2/bringauth"
             async with self._session.post(url, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
 
@@ -212,7 +212,7 @@ class Bring:
 
         """
         try:
-            url = f"{self.url}bringlists/{listUuid}"
+            url = f"{self.url}v2/bringlists/{listUuid}"
             async with self._session.get(url, headers=self.headers) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
@@ -335,7 +335,7 @@ class Bring:
             "specification": specification,
         }
         try:
-            url = f"{self.url}bringlists/{listUuid}"
+            url = f"{self.url}v2/bringlists/{listUuid}"
             async with self._session.put(url, headers=self.putHeaders, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
@@ -390,7 +390,7 @@ class Bring:
         """
         data = {"purchase": itemName, "specification": specification}
         try:
-            url = f"{self.url}bringlists/{listUuid}"
+            url = f"{self.url}v2/bringlists/{listUuid}"
             async with self._session.put(url, headers=self.putHeaders, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
@@ -443,7 +443,7 @@ class Bring:
             "remove": itemName,
         }
         try:
-            url = f"{self.url}bringlists/{listUuid}"
+            url = f"{self.url}v2/bringlists/{listUuid}"
             async with self._session.put(url, headers=self.putHeaders, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
@@ -496,7 +496,7 @@ class Bring:
         """
         data = {"recently": itemName}
         try:
-            url = f"{self.url}bringlists/{listUuid}"
+            url = f"{self.url}v2/bringlists/{listUuid}"
             async with self._session.put(url, headers=self.putHeaders, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
@@ -572,7 +572,7 @@ class Bring:
             else:
                 json["arguments"] = [itemName]
         try:
-            url = f"{self.url}bringnotifications/lists/{listUuid}"
+            url = f"{self.url}v2/bringnotifications/lists/{listUuid}"
             async with self._session.post(
                 url, headers=self.postHeaders, json=json
             ) as r:

--- a/test.py
+++ b/test.py
@@ -8,7 +8,7 @@ import aiohttp
 from dotenv import load_dotenv
 
 from bring_api.bring import Bring
-from bring_api.types import BringList
+from bring_api.types import BringList, BringNotificationType
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -40,6 +40,18 @@ async def test_add_complete_remove(bring: Bring, lst: BringList):
     logging.info("List all items: %s / %s", items["purchase"], items["recently"])
 
 
+async def test_push_notifications(bring: Bring, lst: BringList):
+    """Test sending push notifications."""
+
+    # Send a going shopping notification
+    await bring.notify(lst["listUuid"], BringNotificationType.GOING_SHOPPING, "")
+
+    # Send a urgent message with argument item name
+    await bring.notify(
+        lst["listUuid"], BringNotificationType.URGENT_MESSAGE, "Pouletbrüstli"
+    )
+
+
 async def main():
     """Test Bring API."""
     async with aiohttp.ClientSession() as session:
@@ -54,6 +66,8 @@ async def main():
         logging.info("Selected list: %s (%s)", lst["name"], lst["listUuid"])
 
         await test_add_complete_remove(bring, lst)
+
+        await test_push_notifications(bring, lst)
 
 
 asyncio.run(main())


### PR DESCRIPTION
Removed the `v2/` part from base url. 

I changed all urls to the url that the Bring App uses. Though currently all endpoints in the library work the same no matter if the `v2/` part is present in the url or not, there are may be endpoints that don't work or work differently like this one https://github.com/miaucl/bring-api/wiki/Raw-API-Requests#check-if-user-exists

I want to change to that endpoint in my PR https://github.com/miaucl/bring-api/pull/3