### PR TITLE
Refactor for PEP8 compliance and code clean-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.3.0
+
+* Refactor for PEP8 compliance and code clean-up (breaking change) ([tr4nt0r](https://github.com/tr4nt0r))
+
 ## 0.2.0
 
 * Add new method does_user_exist ([tr4nt0r](https://github.com/tr4nt0r))

--- a/README.md
+++ b/README.md
@@ -42,23 +42,23 @@ async def main():
     await bring.login()
 
     # Get information about all available shopping lists
-    lists = (await bring.loadLists())["lists"]
+    lists = (await bring.load_lists())["lists"]
 
     # Save an item with specifications to a certain shopping list
-    await bring.saveItem(lists[0]['listUuid'], 'Milk', 'low fat')
+    await bring.save_item(lists[0]['listUuid'], 'Milk', 'low fat')
 
     # Save another item
-    await bring.saveItem(lists[0]['listUuid'], 'Carrots')
+    await bring.save_item(lists[0]['listUuid'], 'Carrots')
 
     # Get all the items of a list
-    items = await bring.getItems(lists[0]['listUuid'])
+    items = await bring.get_list(lists[0]['listUuid'])
     print(items)
 
     # Check off an item
-    await bring.completeItem(lists[0]['listUuid'], 'Carrots')
+    await bring.complete_item(lists[0]['listUuid'], 'Carrots')
 
     # Remove an item from a list
-    await bring.removeItem(lists[0]['listUuid'], 'Milk')
+    await bring.remove_item(lists[0]['listUuid'], 'Milk')
 
 asyncio.run(main())
 ```

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -91,7 +91,7 @@ class Bring:
                     raise BringAuthException(
                         "Login failed due to authorization failure, please check your email and password."
                     )
-                elif r.status == 400:
+                if r.status == 400:
                     _LOGGER.error("Exception: Cannot login: %s", await r.text())
                     raise BringAuthException(
                         "Login failed due to bad request, please check your email."

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -140,7 +140,7 @@ class Bring:
 
         return data
 
-    async def loadLists(self) -> BringListResponse:
+    async def load_lists(self) -> BringListResponse:
         """Load all shopping lists.
 
         Returns
@@ -191,12 +191,12 @@ class Bring:
                 "Loading lists failed due to request exception."
             ) from e
 
-    async def getItems(self, listUuid: str) -> BringItemsResponse:
+    async def get_list(self, list_uuid: str) -> BringItemsResponse:
         """Get all items from a shopping list.
 
         Parameters
         ----------
-        listUuid : str
+        list_uuid : str
             A list uuid returned by loadLists()
 
         Returns
@@ -213,7 +213,7 @@ class Bring:
 
         """
         try:
-            url = f"{self.url}v2/bringlists/{listUuid}"
+            url = f"{self.url}v2/bringlists/{list_uuid}"
             async with self._session.get(url, headers=self.headers) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
@@ -231,7 +231,7 @@ class Bring:
                 except JSONDecodeError as e:
                     _LOGGER.error(
                         "Exception: Cannot get items for list %s:\n%s",
-                        listUuid,
+                        list_uuid,
                         traceback.format_exc(),
                     )
                     raise BringParseException(
@@ -240,7 +240,7 @@ class Bring:
         except asyncio.TimeoutError as e:
             _LOGGER.error(
                 "Exception: Cannot get items for list %s:\n%s",
-                listUuid,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
@@ -249,19 +249,21 @@ class Bring:
         except aiohttp.ClientError as e:
             _LOGGER.error(
                 "Exception: Cannot get items for list %s:\n%s",
-                listUuid,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
                 "Loading list items failed due to request exception."
             ) from e
 
-    async def getAllItemDetails(self, listUuid: str) -> BringListItemsDetailsResponse:
+    async def get_all_item_details(
+        self, list_uuid: str
+    ) -> BringListItemsDetailsResponse:
         """Get all details from a shopping list.
 
         Parameters
         ----------
-        listUuid : str
+        list_uuid : str
             A list uuid returned by loadLists()
 
         Returns
@@ -282,7 +284,7 @@ class Bring:
 
         """
         try:
-            url = f"{self.url}bringlists/{listUuid}/details"
+            url = f"{self.url}bringlists/{list_uuid}/details"
             async with self._session.get(url, headers=self.headers) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
@@ -303,7 +305,7 @@ class Bring:
                 except JSONDecodeError as e:
                     _LOGGER.error(
                         "Exception: Cannot get item details for list %s:\n%s",
-                        listUuid,
+                        list_uuid,
                         traceback.format_exc(),
                     )
                     raise BringParseException(
@@ -312,7 +314,7 @@ class Bring:
         except asyncio.TimeoutError as e:
             _LOGGER.error(
                 "Exception: Cannot get item details for list %s:\n%s",
-                listUuid,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
@@ -321,23 +323,23 @@ class Bring:
         except aiohttp.ClientError as e:
             _LOGGER.error(
                 "Exception: Cannot get item details for list %s:\n%s",
-                listUuid,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
                 "Loading list details failed due to request exception."
             ) from e
 
-    async def saveItem(
-        self, listUuid: str, itemName: str, specification: str = ""
+    async def save_item(
+        self, list_uuid: str, item_name: str, specification: str = ""
     ) -> aiohttp.ClientResponse:
         """Save an item to a shopping list.
 
         Parameters
         ----------
-        listUuid : str
+        list_uuid : str
             A list uuid returned by loadLists()
-        itemName : str
+        item_name : str
             The name of the item you want to save.
         specification : str, optional
             The details you want to add to the item.
@@ -354,11 +356,11 @@ class Bring:
 
         """
         data = {
-            "purchase": itemName,
+            "purchase": item_name,
             "specification": specification,
         }
         try:
-            url = f"{self.url}v2/bringlists/{listUuid}"
+            url = f"{self.url}v2/bringlists/{list_uuid}"
             async with self._session.put(url, headers=self.headers, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
@@ -366,38 +368,38 @@ class Bring:
         except asyncio.TimeoutError as e:
             _LOGGER.error(
                 "Exception: Cannot save item %s (%s) to list %s:\n%s",
-                itemName,
+                item_name,
                 specification,
-                listUuid,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Saving item {itemName} ({specification}) to list {listUuid}"
+                f"Saving item {item_name} ({specification}) to list {list_uuid}"
                 "failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
             _LOGGER.error(
                 "Exception: Cannot save item %s (%s) to list %s:\n%s",
-                itemName,
+                item_name,
                 specification,
-                listUuid,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Saving item {itemName} ({specification}) to list {listUuid}"
+                f"Saving item {item_name} ({specification}) to list {list_uuid}"
                 "failed due to request exception."
             ) from e
 
-    async def updateItem(
-        self, listUuid: str, itemName: str, specification: str = ""
+    async def update_item(
+        self, list_uuid: str, item_name: str, specification: str = ""
     ) -> aiohttp.ClientResponse:
         """Update an existing list item.
 
         Parameters
         ----------
-        listUuid : str
+        list_uuid : str
             A list uuid returned by loadLists()
-        itemName : str
+        item_name : str
             The name of the item you want to update.
         specification : str, optional
             The details you want to update on the item.
@@ -413,9 +415,9 @@ class Bring:
             If the request fails.
 
         """
-        data = {"purchase": itemName, "specification": specification}
+        data = {"purchase": item_name, "specification": specification}
         try:
-            url = f"{self.url}v2/bringlists/{listUuid}"
+            url = f"{self.url}v2/bringlists/{list_uuid}"
             async with self._session.put(url, headers=self.headers, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
@@ -423,36 +425,38 @@ class Bring:
         except asyncio.TimeoutError as e:
             _LOGGER.error(
                 "Exception: Cannot update item %s (%s) to list %s:\n%s",
-                itemName,
+                item_name,
                 specification,
-                listUuid,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Updating item {itemName} ({specification}) in list {listUuid}"
+                f"Updating item {item_name} ({specification}) in list {list_uuid}"
                 "failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
             _LOGGER.error(
                 "Exception: Cannot update item %s (%s) to list %s:\n%s",
-                itemName,
+                item_name,
                 specification,
-                listUuid,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Updating item {itemName} ({specification}) in list {listUuid}"
+                f"Updating item {item_name} ({specification}) in list {list_uuid}"
                 "failed due to request exception."
             ) from e
 
-    async def removeItem(self, listUuid: str, itemName: str) -> aiohttp.ClientResponse:
+    async def remove_item(
+        self, list_uuid: str, item_name: str
+    ) -> aiohttp.ClientResponse:
         """Remove an item from a shopping list.
 
         Parameters
         ----------
-        listUuid : str
+        list_uuid : str
             A list uuid returned by loadLists()
-        itemName : str
+        item_name : str
             The name of the item you want to remove.
 
         Returns
@@ -467,10 +471,10 @@ class Bring:
 
         """
         data = {
-            "remove": itemName,
+            "remove": item_name,
         }
         try:
-            url = f"{self.url}v2/bringlists/{listUuid}"
+            url = f"{self.url}v2/bringlists/{list_uuid}"
             async with self._session.put(url, headers=self.headers, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
@@ -478,28 +482,28 @@ class Bring:
         except asyncio.TimeoutError as e:
             _LOGGER.error(
                 "Exception: Cannot delete item %s from list %s:\n%s",
-                itemName,
-                listUuid,
+                item_name,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Removing item {itemName} from list {listUuid}"
+                f"Removing item {item_name} from list {list_uuid}"
                 "failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
             _LOGGER.error(
                 "Exception: Cannot delete item %s from list %s:\n%s",
-                itemName,
-                listUuid,
+                item_name,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Removing item {itemName} from list {listUuid}"
+                f"Removing item {item_name} from list {list_uuid}"
                 "failed due to request exception."
             ) from e
 
-    async def completeItem(
-        self, listUuid: str, itemName: str
+    async def complete_item(
+        self, list_uuid: str, item_name: str
     ) -> aiohttp.ClientResponse:
         """Complete an item from a shopping list. This will add it to recent items.
 
@@ -507,9 +511,9 @@ class Bring:
 
         Parameters
         ----------
-        listUuid : str
+        list_uuid : str
             A list uuid returned by loadLists()
-        itemName : str
+        item_name : str
             The name of the item you want to complete.
 
         Returns
@@ -523,9 +527,9 @@ class Bring:
             If the request fails.
 
         """
-        data = {"recently": itemName}
+        data = {"recently": item_name}
         try:
-            url = f"{self.url}v2/bringlists/{listUuid}"
+            url = f"{self.url}v2/bringlists/{list_uuid}"
             async with self._session.put(url, headers=self.headers, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
@@ -533,39 +537,39 @@ class Bring:
         except asyncio.TimeoutError as e:
             _LOGGER.error(
                 "Exception: Cannot complete item %s in list %s:\n%s",
-                itemName,
-                listUuid,
+                item_name,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Completing item {itemName} from list {listUuid} failed due to connection timeout."
+                f"Completing item {item_name} from list {list_uuid} failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
             _LOGGER.error(
                 "Exception: Cannot complete item %s in list %s:\n%s",
-                itemName,
-                listUuid,
+                item_name,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Completing item {itemName} from list {listUuid} failed due to request exception."
+                f"Completing item {item_name} from list {list_uuid} failed due to request exception."
             ) from e
 
     async def notify(
         self,
-        listUuid: str,
-        notificationType: BringNotificationType,
-        itemName: str,
+        list_uuid: str,
+        notification_type: BringNotificationType,
+        item_name: str,
     ) -> aiohttp.ClientResponse:
         """Send a push notification to all other members of a shared list.
 
         Parameters
         ----------
-        listUuid : str
+        list_uuid : str
             A list uuid returned by loadLists()
-        notificationType : BringNotificationType
+        notification_type : BringNotificationType
             The type of notification to be sent
-        itemName : str, optional
+        item_name : str, optional
             The text that **must** be included in the URGENT_MESSAGE BringNotificationType.
 
         Returns
@@ -581,28 +585,28 @@ class Bring:
         """
         json = BringNotificationsConfigType(
             arguments=[],
-            listNotificationType=notificationType.value,
+            listNotificationType=notification_type.value,
             senderPublicUserUuid=self.public_uuid,
         )
 
-        if not isinstance(notificationType, BringNotificationType):
+        if not isinstance(notification_type, BringNotificationType):
             _LOGGER.error(
-                "Exception: notificationType %s not supported.", notificationType
+                "Exception: notificationType %s not supported.", notification_type
             )
             raise TypeError(
-                f"notificationType {notificationType} not supported,"
+                f"notificationType {notification_type} not supported,"
                 "must be of type BringNotificationType."
             )
-        if notificationType is BringNotificationType.URGENT_MESSAGE:
-            if not itemName or len(itemName) == 0:
+        if notification_type is BringNotificationType.URGENT_MESSAGE:
+            if not item_name or len(item_name) == 0:
                 _LOGGER.error("Exception: Argument itemName missing.")
                 raise ValueError(
                     "notificationType is URGENT_MESSAGE but argument itemName missing."
                 )
             else:
-                json["arguments"] = [itemName]
+                json["arguments"] = [item_name]
         try:
-            url = f"{self.url}v2/bringnotifications/lists/{listUuid}"
+            url = f"{self.url}v2/bringnotifications/lists/{list_uuid}"
             async with self._session.post(url, headers=self.headers, json=json) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
@@ -610,23 +614,23 @@ class Bring:
         except asyncio.TimeoutError as e:
             _LOGGER.error(
                 "Exception: Cannot send notification %s for list %s:\n%s",
-                notificationType,
-                listUuid,
+                notification_type,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Sending notification {notificationType} for list {listUuid}"
+                f"Sending notification {notification_type} for list {list_uuid}"
                 "failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
             _LOGGER.error(
                 "Exception: Cannot send notification %s for list %s:\n%s",
-                notificationType,
-                listUuid,
+                notification_type,
+                list_uuid,
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Sending notification {notificationType} for list {listUuid}"
+                f"Sending notification {notification_type} for list {list_uuid}"
                 "failed due to request exception."
             ) from e
 

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -605,8 +605,8 @@ class Bring:
                 raise ValueError(
                     "notificationType is URGENT_MESSAGE but argument itemName missing."
                 )
-            else:
-                json["arguments"] = [item_name]
+
+            json["arguments"] = [item_name]
         try:
             url = f"{self.url}v2/bringnotifications/lists/{list_uuid}"
             async with self._session.post(url, headers=self.headers, json=json) as r:

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -89,7 +89,8 @@ class Bring:
                     else:
                         _LOGGER.error("Exception: Cannot login: %s", errmsg["message"])
                     raise BringAuthException(
-                        "Login failed due to authorization failure, please check your email and password."
+                        "Login failed due to authorization failure, "
+                        "please check your email and password."
                     )
                 if r.status == 400:
                     _LOGGER.error("Exception: Cannot login: %s", await r.text())
@@ -128,7 +129,8 @@ class Bring:
         if "uuid" not in data or "access_token" not in data:
             _LOGGER.error("Exception: Cannot login: Data missing in API response.")
             raise BringAuthException(
-                "Login failed due to missing data in the API response, please check your email and password."
+                "Login failed due to missing data in the API response,"
+                "please check your email and password."
             )
 
         self.uuid = data["uuid"]
@@ -266,9 +268,10 @@ class Bring:
         -------
         list
             The JSON response as a list. A list of item details.
-            Caution: This is NOT a list of the items currently marked as 'to buy'. See getItems() for that.
-            This contains the items that where customized by changing their default icon, category or uploading
-            an image.
+            Caution: This is NOT a list of the items currently marked as 'to buy'.
+            See getItems() for that.
+            This contains the items that where customized by changing
+            their default icon, category or uploading an image.
 
         Raises
         ------
@@ -369,7 +372,8 @@ class Bring:
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Saving item {itemName} ({specification}) to list {listUuid} failed due to connection timeout."
+                f"Saving item {itemName} ({specification}) to list {listUuid}"
+                "failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
             _LOGGER.error(
@@ -380,7 +384,8 @@ class Bring:
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Saving item {itemName} ({specification}) to list {listUuid} failed due to request exception."
+                f"Saving item {itemName} ({specification}) to list {listUuid}"
+                "failed due to request exception."
             ) from e
 
     async def updateItem(
@@ -424,7 +429,8 @@ class Bring:
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Updating item {itemName} ({specification}) in list {listUuid} failed due to connection timeout."
+                f"Updating item {itemName} ({specification}) in list {listUuid}"
+                "failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
             _LOGGER.error(
@@ -435,7 +441,8 @@ class Bring:
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Updating item {itemName} ({specification}) in list {listUuid} failed due to request exception."
+                f"Updating item {itemName} ({specification}) in list {listUuid}"
+                "failed due to request exception."
             ) from e
 
     async def removeItem(self, listUuid: str, itemName: str) -> aiohttp.ClientResponse:
@@ -476,7 +483,8 @@ class Bring:
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Removing item {itemName} from list {listUuid} failed due to connection timeout."
+                f"Removing item {itemName} from list {listUuid}"
+                "failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
             _LOGGER.error(
@@ -486,7 +494,8 @@ class Bring:
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Removing item {itemName} from list {listUuid} failed due to request exception."
+                f"Removing item {itemName} from list {listUuid}"
+                "failed due to request exception."
             ) from e
 
     async def completeItem(
@@ -581,7 +590,8 @@ class Bring:
                 "Exception: notificationType %s not supported.", notificationType
             )
             raise TypeError(
-                f"notificationType {notificationType} not supported, must be of type BringNotificationType."
+                f"notificationType {notificationType} not supported,"
+                "must be of type BringNotificationType."
             )
         if notificationType is BringNotificationType.URGENT_MESSAGE:
             if not itemName or len(itemName) == 0:
@@ -605,7 +615,8 @@ class Bring:
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Sending notification {notificationType} for list {listUuid} failed due to connection timeout."
+                f"Sending notification {notificationType} for list {listUuid}"
+                "failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
             _LOGGER.error(
@@ -615,7 +626,8 @@ class Bring:
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Sending notification {notificationType} for list {listUuid} failed due to request exception."
+                f"Sending notification {notificationType} for list {listUuid}"
+                "failed due to request exception."
             ) from e
 
     async def does_user_exist(self, mail: Optional[str] = None) -> bool:

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -542,7 +542,8 @@ class Bring:
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Completing item {item_name} from list {list_uuid} failed due to connection timeout."
+                f"Completing item {item_name} from list {list_uuid}"
+                "failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
             _LOGGER.error(
@@ -552,7 +553,8 @@ class Bring:
                 traceback.format_exc(),
             )
             raise BringRequestException(
-                f"Completing item {item_name} from list {list_uuid} failed due to request exception."
+                f"Completing item {item_name} from list {list_uuid}"
+                "failed due to request exception."
             ) from e
 
     async def notify(

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -51,24 +51,6 @@ class Bring:
             "X-BRING-COUNTRY": "DE",
             "X-BRING-USER-UUID": "",
         }
-        self.putHeaders = {
-            "Authorization": "",
-            "X-BRING-API-KEY": "",
-            "X-BRING-CLIENT-SOURCE": "",
-            "X-BRING-CLIENT": "",
-            "X-BRING-COUNTRY": "",
-            "X-BRING-USER-UUID": "",
-            "Content-Type": "",
-        }
-        self.postHeaders = {
-            "Authorization": "",
-            "X-BRING-API-KEY": "",
-            "X-BRING-CLIENT-SOURCE": "",
-            "X-BRING-CLIENT": "",
-            "X-BRING-COUNTRY": "",
-            "X-BRING-USER-UUID": "",
-            "Content-Type": "",
-        }
 
     async def login(self) -> BringAuthResponse:
         """Try to login.
@@ -153,14 +135,7 @@ class Bring:
         self.public_uuid = data.get("publicUuid", "")
         self.headers["X-BRING-USER-UUID"] = self.uuid
         self.headers["Authorization"] = f'Bearer {data["access_token"]}'
-        self.putHeaders = {
-            **self.headers,
-            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-        }
-        self.postHeaders = {
-            **self.headers,
-            "Content-Type": "application/json; charset=UTF-8",
-        }
+
         return data
 
     async def loadLists(self) -> BringListResponse:
@@ -381,7 +356,7 @@ class Bring:
         }
         try:
             url = f"{self.url}v2/bringlists/{listUuid}"
-            async with self._session.put(url, headers=self.putHeaders, data=data) as r:
+            async with self._session.put(url, headers=self.headers, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
                 return r
@@ -436,7 +411,7 @@ class Bring:
         data = {"purchase": itemName, "specification": specification}
         try:
             url = f"{self.url}v2/bringlists/{listUuid}"
-            async with self._session.put(url, headers=self.putHeaders, data=data) as r:
+            async with self._session.put(url, headers=self.headers, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
                 return r
@@ -489,7 +464,7 @@ class Bring:
         }
         try:
             url = f"{self.url}v2/bringlists/{listUuid}"
-            async with self._session.put(url, headers=self.putHeaders, data=data) as r:
+            async with self._session.put(url, headers=self.headers, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
                 return r
@@ -542,7 +517,7 @@ class Bring:
         data = {"recently": itemName}
         try:
             url = f"{self.url}v2/bringlists/{listUuid}"
-            async with self._session.put(url, headers=self.putHeaders, data=data) as r:
+            async with self._session.put(url, headers=self.headers, data=data) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
                 return r
@@ -618,9 +593,7 @@ class Bring:
                 json["arguments"] = [itemName]
         try:
             url = f"{self.url}v2/bringnotifications/lists/{listUuid}"
-            async with self._session.post(
-                url, headers=self.postHeaders, json=json
-            ) as r:
+            async with self._session.post(url, headers=self.headers, json=json) as r:
                 _LOGGER.debug("Response from %s: %s", url, r.status)
                 r.raise_for_status()
                 return r

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -39,7 +39,7 @@ class Bring:
         self.mail = mail
         self.password = password
         self.uuid = ""
-        self.publicUuid = ""
+        self.public_uuid = ""
 
         self.url = "https://api.getbring.com/rest/"
 
@@ -150,7 +150,7 @@ class Bring:
             )
 
         self.uuid = data["uuid"]
-        self.publicUuid = data.get("publicUuid", "")
+        self.public_uuid = data.get("publicUuid", "")
         self.headers["X-BRING-USER-UUID"] = self.uuid
         self.headers["Authorization"] = f'Bearer {data["access_token"]}'
         self.putHeaders = {
@@ -598,7 +598,7 @@ class Bring:
         json = BringNotificationsConfigType(
             arguments=[],
             listNotificationType=notificationType.value,
-            senderPublicUserUuid=self.publicUuid,
+            senderPublicUserUuid=self.public_uuid,
         )
 
         if not isinstance(notificationType, BringNotificationType):

--- a/bring_api/exceptions.py
+++ b/bring_api/exceptions.py
@@ -4,25 +4,17 @@
 class BringException(Exception):
     """General exception occurred."""
 
-    pass
-
 
 class BringAuthException(BringException):
     """When an authentication error is encountered."""
-
-    pass
 
 
 class BringRequestException(BringException):
     """When the HTTP request fails."""
 
-    pass
-
 
 class BringParseException(BringException):
     """When parsing the response of a request fails."""
-
-    pass
 
 
 class BringEMailInvalidException(BringException):

--- a/bring_api/types.py
+++ b/bring_api/types.py
@@ -68,8 +68,6 @@ class BringItemsResponse(TypedDict):
 class BringListItemsDetailsResponse(List[BringListItemDetails]):
     """A response class of a list of item details."""
 
-    pass
-
 
 class BringNotificationType(Enum):
     """Notification type.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bring-api
-version = 0.2.0
+version = 0.3.0
 author = Cyrill Raccaud
 author_email = cyrill.raccaud+pypi@gmail.com
 description = Unofficial package to access Bring! shopping lists API.

--- a/test.py
+++ b/test.py
@@ -21,24 +21,24 @@ async def test_add_complete_remove(bring: Bring, lst: BringList):
     """Test add-complete-remove for an item."""
 
     # Save an item with specifications to a certain shopping list
-    await bring.saveItem(lst["listUuid"], "Äpfel", "low fat")
+    await bring.save_item(lst["listUuid"], "Äpfel", "low fat")
 
     # Get all the pending items of a list
-    items = await bring.getItems(lst["listUuid"])
+    items = await bring.get_list(lst["listUuid"])
     logging.info("List purchase items: %s", items["purchase"])
 
     # Check of an item
-    await bring.completeItem(lst["listUuid"], items["purchase"][0]["itemId"])
+    await bring.complete_item(lst["listUuid"], items["purchase"][0]["itemId"])
 
     # Get all the recent items of a list
-    items = await bring.getItems(lst["listUuid"])
+    items = await bring.get_list(lst["listUuid"])
     logging.info("List recently items: %s", items["recently"])
 
     # Remove an item from a list
-    await bring.removeItem(lst["listUuid"], "Äpfel")
+    await bring.remove_item(lst["listUuid"], "Äpfel")
 
     # Get all the items of a list
-    items = await bring.getItems(lst["listUuid"])
+    items = await bring.get_list(lst["listUuid"])
     logging.info("List all items: %s / %s", items["purchase"], items["recently"])
 
 
@@ -89,7 +89,7 @@ async def main():
         await bring.login()
 
         # Get information about all available shopping list and select one to test with
-        lists = (await bring.loadLists())["lists"]
+        lists = (await bring.load_lists())["lists"]
         lst = next(lst for lst in lists if lst["name"] == os.environ["LIST"])
         logging.info("Selected list: %s (%s)", lst["name"], lst["listUuid"])
 


### PR DESCRIPTION
This PR refactors the bring-api for PEP8 compliance and is therefore a breaking change.

Method names and variables are renamed to snake_case but also to better reflect the method names used in the Bring App ([see here](https://github.com/miaucl/bring-api/wiki/PEP8-compliant-method-renaming)). 

Warnings from ruff are addressed, like too long lines or unnecessary code removed.