### PR TITLE
revert change of notify method

### DIFF
--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -561,7 +561,7 @@ class Bring:
         self,
         list_uuid: str,
         notification_type: BringNotificationType,
-        item_name: str,
+        item_name: Optional[str] = None,
     ) -> aiohttp.ClientResponse:
         """Send a push notification to all other members of a shared list.
 

--- a/test.py
+++ b/test.py
@@ -46,7 +46,7 @@ async def test_push_notifications(bring: Bring, lst: BringList):
     """Test sending push notifications."""
 
     # Send a going shopping notification
-    await bring.notify(lst["listUuid"], BringNotificationType.GOING_SHOPPING, "")
+    await bring.notify(lst["listUuid"], BringNotificationType.GOING_SHOPPING)
 
     # Send a urgent message with argument item name
     await bring.notify(


### PR DESCRIPTION
make parameter item_name optional

already raises ValueError when None
or empty for BringNotificationType.URGENT_MESSAGE

