### PR TITLE
add data explicitly to packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,14 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
-packages = bring_api
+packages = 
+    bring_api
+    bring_api.locales
 python_requires = >=3.8
 install_requires =
     aiohttp
 include_package_data = True
+
+[options.package_data]
+bring_api.locales =
+    *.json


### PR DESCRIPTION
updated setup.cfg to explicitly add locales as package. setuptools stated it as ambigious locally but the locales where added anyway. The build process on github on the other hand, did not add the locales folder. 