### PR TITLE
fix KeyError when listArticleLanguage is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.5.5
+
+* Fix KeyError when listArticleLanguage is not set.
+  
 ## 0.5.4
 
 * Load article translations from file in executor instead of event loop.

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -788,7 +788,7 @@ class Bring:
         locales_required = list(
             dict.fromkeys(
                 [
-                    list_setting["listArticleLanguage"]
+                    list_setting.get("listArticleLanguage", self.user_locale)
                     for list_setting in self.user_list_settings.values()
                 ]
                 + [self.user_locale]
@@ -1061,7 +1061,9 @@ class Bring:
 
         """
         if list_uuid in self.user_list_settings:
-            return self.user_list_settings[list_uuid]["listArticleLanguage"]
+            return self.user_list_settings[list_uuid].get(
+                "listArticleLanguage", self.user_locale
+            )
         return self.user_locale
 
     async def get_user_account(self) -> BringSyncCurrentUserResponse:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bring-api
-version = 0.5.4
+version = 0.5.5
 author = Cyrill Raccaud
 author_email = cyrill.raccaud+pypi@gmail.com
 description = Unofficial package to access Bring! shopping lists API.

--- a/test.py
+++ b/test.py
@@ -83,7 +83,9 @@ async def test_translation(bring: Bring, lst: BringList):
     locale_to = "de-DE"
     locale_from = "de-CH"
 
-    locale_org = bring.user_list_settings[lst["listUuid"]]["listArticleLanguage"]
+    locale_org = bring.user_list_settings[lst["listUuid"]].get(
+        "listArticleLanguage", bring.user_locale
+    )
 
     test_items = {
         "Pouletbrüstli": "Hähnchenbrust",


### PR DESCRIPTION
Fixes a rare condition where listArticleLanguage is not set in user_list_settings. 

The following response resulted in the same KeyError as described in this issue:
- https://github.com/home-assistant/core/issues/112091

```
{
  "usersettings": [
    {
      "key": "autoPush",
      "value": "ON"
    },
    {
      "key": "defaultListUUID",
      "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
    },
    {
      "key": "onboardClient",
      "value": "webApp"
    }
  ],
  "userlistsettings": [
    {
      "listUuid": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
      "usersettings": [
        {
          "key": "listSectionOrder",
          "value": "[\"Brot & Gebäck\",\"Milch & Käse\",\"Fleisch & Fisch\",\"Zutaten & Gewürze\",\"Früchte & Gemüse\",\"Fertig- & Tiefkühlprodukte\",\"Getreideprodukte\",\"Snacks & Süsswaren\",\"Getränke & Tabak\",\"Haushalt & Gesundheit\",\"Pflege & Gesundheit\",\"Tierbedarf\",\"Baumarkt & Garten\",\"Eigene Artikel\"]"
        }
      ]
    }
  ]
}
```

