### PR TITLE
fixed incorrect filtering of locales against supported locales list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.5.6
+
+* fix incorrect filtering of locales against supported locales list
+
 ## 0.5.5
 
 * Fix KeyError when listArticleLanguage is not set.

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -795,8 +795,8 @@ class Bring:
             )
         )
 
-        for locale in locales_required or BRING_SUPPORTED_LOCALES:
-            if locale == BRING_DEFAULT_LOCALE:
+        for locale in locales_required:
+            if locale == BRING_DEFAULT_LOCALE or locale not in BRING_SUPPORTED_LOCALES:
                 continue
 
             try:
@@ -826,7 +826,7 @@ class Bring:
                             traceback.format_exc(),
                         )
                         raise BringParseException(
-                            f"Loading article translations for locale {locale}"
+                            f"Loading article translations for locale {locale} "
                             "failed during parsing of request response."
                         ) from e
             except asyncio.TimeoutError as e:
@@ -836,7 +836,7 @@ class Bring:
                     traceback.format_exc(),
                 )
                 raise BringRequestException(
-                    f"Loading article translations for locale {locale}"
+                    f"Loading article translations for locale {locale} "
                     "failed due to connection timeout."
                 ) from e
 
@@ -847,7 +847,7 @@ class Bring:
                     traceback.format_exc(),
                 )
                 raise BringRequestException(
-                    f"Loading article translations for locale {locale}"
+                    f"Loading article translations for locale {locale} "
                     "failed due to request exception."
                 ) from e
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bring-api
-version = 0.5.5
+version = 0.5.6
 author = Cyrill Raccaud
 author_email = cyrill.raccaud+pypi@gmail.com
 description = Unofficial package to access Bring! shopping lists API.


### PR DESCRIPTION
In case that a list had no locale assigned (which happens when onboarding happens in the webApp) there is a fallback to using language and country from the user account to create a locale. But it wasn't taken into account that combinations are possible, that are not supported locales. I think when user have phone language in english but register from Germany, this results in a locale en-DE. Unfortunately filtering against the supported locales did not work correctly and resulted in 2 exceptions, when trying to load a non-existing locale from file system and when trying to download a non-existing locale from the bring server.