### PR TITLE
change implicit to explicit string conversion of BringItemOperation

### DIFF
--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -1155,7 +1155,7 @@ class Bring:
                         item["itemId"],
                         from_locale=self.__locale(list_uuid),
                     ),
-                    "operation": item.get("operation", operation.value),
+                    "operation": str(item.get("operation", operation)),
                 }
                 for item in items
             ],

--- a/bring_api/types.py
+++ b/bring_api/types.py
@@ -1,7 +1,7 @@
 """Bring API types."""
 
-from enum import Enum
-from typing import List, NotRequired, TypedDict
+from enum import Enum, StrEnum
+from typing import List, Literal, NotRequired, TypedDict
 
 
 class BringList(TypedDict):
@@ -127,7 +127,7 @@ class BringSyncCurrentUserResponse(TypedDict):
     userUuid: str
 
 
-class BringItemOperation(Enum):
+class BringItemOperation(StrEnum):
     """Operation to be be executed on list items."""
 
     ADD = "TO_PURCHASE"
@@ -141,4 +141,6 @@ class BringItem(TypedDict):
     itemId: str
     spec: str
     uuid: str
-    operation: NotRequired[BringItemOperation]
+    operation: NotRequired[
+        BringItemOperation | Literal["TO_PURCHASE", "TO_RECENTLY", "REMOVE"]
+    ]


### PR DESCRIPTION
* explicit conversion of `BringItemOperation` enum values to corresponding strings instead of implicit conversion by aiohttp 
* Change Type of BringItemOperation to StrEnum for explicit string conversion
* Add string literals `TO_PURCHASE`, `TO_RECENTLY`, `REMOVE` to `BringItem` 