### PR TITLE
Log to debug instead of error and add raw server response to debug log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+# 0.7.1
+
+* Log to debug instead of error where exceptions are already raised.
+* Add raw server response to debug log messages.
+
 # 0.7.0
 
 * **New API method:** `retrieve_new_access_token` retrieves a new access token and updates authorization headers. Time till expiration of the access token is stored in the property `expires_in` . ([tr4nt0r](https://github.com/tr4nt0r))

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -869,7 +869,7 @@ class Bring:
             try:
                 url = f"{LOCALES_BASE_URL}articles.{locale}.json"
                 async with self._session.get(url) as r:
-                    _LOGGER.debug("Response from %s [%s]: %s", url, r.status, r.text)
+                    _LOGGER.debug("Response from %s [%s]", url, r.status)
                     r.raise_for_status()
 
                     try:

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -108,13 +108,13 @@ class Bring:
         try:
             url = f"{self.url}v2/bringauth"
             async with self._session.post(url, data=user_data) as r:
-                _LOGGER.debug("Response from %s: %s", url, r.status)
+                _LOGGER.debug("Response from %s [%s]: %s", url, r.status, r.text)
 
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
                     except JSONDecodeError as e:
-                        _LOGGER.error(
+                        _LOGGER.debug(
                             "Exception: Cannot parse login request response:\n %s",
                             traceback.format_exc(),
                         )
@@ -122,13 +122,13 @@ class Bring:
                             "Login failed due to authorization failure "
                             "but error response could not be parsed."
                         ) from e
-                    _LOGGER.error("Exception: Cannot login: %s", errmsg["message"])
+                    _LOGGER.debug("Exception: Cannot login: %s", errmsg["message"])
                     raise BringAuthException(
                         "Login failed due to authorization failure, "
                         "please check your email and password."
                     )
                 if r.status == HTTPStatus.BAD_REQUEST:
-                    _LOGGER.error("Exception: Cannot login: %s", await r.text())
+                    _LOGGER.debug("Exception: Cannot login: %s", await r.text())
                     raise BringAuthException(
                         "Login failed due to bad request, please check your email."
                     )
@@ -144,19 +144,19 @@ class Bring:
                         },
                     )
                 except JSONDecodeError as e:
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot login:\n %s", traceback.format_exc()
                     )
                     raise BringParseException(
                         "Cannot parse login request response."
                     ) from e
         except asyncio.TimeoutError as e:
-            _LOGGER.error("Exception: Cannot login:\n %s", traceback.format_exc())
+            _LOGGER.debug("Exception: Cannot login:\n %s", traceback.format_exc())
             raise BringRequestException(
                 "Authentication failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
-            _LOGGER.error("Exception: Cannot login:\n %s", traceback.format_exc())
+            _LOGGER.debug("Exception: Cannot login:\n %s", traceback.format_exc())
             raise BringRequestException(
                 "Authentication failed due to request exception."
             ) from e
@@ -198,13 +198,13 @@ class Bring:
         try:
             url = f"{self.url}bringusers/{self.uuid}/lists"
             async with self._session.get(url, headers=self.headers) as r:
-                _LOGGER.debug("Response from %s: %s", url, r.status)
+                _LOGGER.debug("Response from %s [%s]: %s", url, r.status, r.text)
 
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
                     except JSONDecodeError as e:
-                        _LOGGER.error(
+                        _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
@@ -212,7 +212,7 @@ class Bring:
                             "Loading lists failed due to authorization failure but "
                             "error response could not be parsed."
                         ) from e
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot get lists: %s",
                         errmsg["message"],
                     )
@@ -234,19 +234,19 @@ class Bring:
                     )
                     return data
                 except JSONDecodeError as e:
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot get lists:\n %s", traceback.format_exc()
                     )
                     raise BringParseException(
                         "Loading lists failed during parsing of request response."
                     ) from e
         except asyncio.TimeoutError as e:
-            _LOGGER.error("Exception: Cannot get lists:\n %s", traceback.format_exc())
+            _LOGGER.debug("Exception: Cannot get lists:\n %s", traceback.format_exc())
             raise BringRequestException(
                 "Loading list failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
-            _LOGGER.error("Exception: Cannot get lists:\n %s", traceback.format_exc())
+            _LOGGER.debug("Exception: Cannot get lists:\n %s", traceback.format_exc())
             raise BringRequestException(
                 "Loading lists failed due to request exception."
             ) from e
@@ -275,13 +275,13 @@ class Bring:
         try:
             url = f"{self.url}v2/bringlists/{list_uuid}"
             async with self._session.get(url, headers=self.headers) as r:
-                _LOGGER.debug("Response from %s: %s", url, r.status)
+                _LOGGER.debug("Response from %s [%s]: %s", url, r.status, r.text)
 
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
                     except JSONDecodeError as e:
-                        _LOGGER.error(
+                        _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
@@ -289,7 +289,7 @@ class Bring:
                             "Loading list items failed due to authorization failure but "
                             "error response could not be parsed."
                         ) from e
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot get list items: %s",
                         errmsg["message"],
                     )
@@ -319,7 +319,7 @@ class Bring:
 
                     return data
                 except JSONDecodeError as e:
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot get items for list %s:\n%s",
                         list_uuid,
                         traceback.format_exc(),
@@ -328,7 +328,7 @@ class Bring:
                         "Loading list items failed during parsing of request response."
                     ) from e
         except asyncio.TimeoutError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot get items for list %s:\n%s",
                 list_uuid,
                 traceback.format_exc(),
@@ -337,7 +337,7 @@ class Bring:
                 "Loading list items failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot get items for list %s:\n%s",
                 list_uuid,
                 traceback.format_exc(),
@@ -376,13 +376,13 @@ class Bring:
         try:
             url = f"{self.url}bringlists/{list_uuid}/details"
             async with self._session.get(url, headers=self.headers) as r:
-                _LOGGER.debug("Response from %s: %s", url, r.status)
+                _LOGGER.debug("Response from %s [%s]: %s", url, r.status, r.text)
 
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
                     except JSONDecodeError as e:
-                        _LOGGER.error(
+                        _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
@@ -390,7 +390,7 @@ class Bring:
                             "Loading list details failed due to authorization failure but "
                             "error response could not be parsed."
                         ) from e
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot get list details: %s",
                         errmsg["message"],
                     )
@@ -415,7 +415,7 @@ class Bring:
                     ]
                     return cast(BringListItemsDetailsResponse, data)
                 except JSONDecodeError as e:
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot get item details for list %s:\n%s",
                         list_uuid,
                         traceback.format_exc(),
@@ -424,7 +424,7 @@ class Bring:
                         "Loading list details failed during parsing of request response."
                     ) from e
         except asyncio.TimeoutError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot get item details for list %s:\n%s",
                 list_uuid,
                 traceback.format_exc(),
@@ -433,7 +433,7 @@ class Bring:
                 "Loading list details failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot get item details for list %s:\n%s",
                 list_uuid,
                 traceback.format_exc(),
@@ -482,7 +482,7 @@ class Bring:
         try:
             return await self.batch_update_list(list_uuid, data, BringItemOperation.ADD)
         except BringRequestException as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot save item %s (%s) to list %s:\n%s",
                 item_name,
                 specification,
@@ -538,7 +538,7 @@ class Bring:
         try:
             return await self.batch_update_list(list_uuid, data, BringItemOperation.ADD)
         except BringRequestException as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot update item %s (%s) to list %s:\n%s",
                 item_name,
                 specification,
@@ -585,7 +585,7 @@ class Bring:
                 list_uuid, data, BringItemOperation.REMOVE
             )
         except BringRequestException as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot delete item %s from list %s:\n%s",
                 item_name,
                 list_uuid,
@@ -639,7 +639,7 @@ class Bring:
                 list_uuid, data, BringItemOperation.COMPLETE
             )
         except BringRequestException as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot complete item %s in list %s:\n%s",
                 item_name,
                 list_uuid,
@@ -685,8 +685,10 @@ class Bring:
         )
 
         if not isinstance(notification_type, BringNotificationType):
-            _LOGGER.error(
-                "Exception: notificationType %s not supported.", notification_type
+            _LOGGER.debug(
+                "Exception: notificationType %s not supported. \n%s",
+                notification_type,
+                traceback.format_exc(),
             )
             raise TypeError(
                 f"notificationType {notification_type} not supported,"
@@ -694,7 +696,9 @@ class Bring:
             )
         if notification_type is BringNotificationType.URGENT_MESSAGE:
             if not item_name or len(item_name) == 0:
-                _LOGGER.error("Exception: Argument itemName missing.")
+                _LOGGER.debug(
+                    "Exception: Argument itemName missing:\n%s", traceback.format_exc()
+                )
                 raise ValueError(
                     "notificationType is URGENT_MESSAGE but argument itemName missing."
                 )
@@ -705,13 +709,13 @@ class Bring:
             async with self._session.post(
                 url, headers=self.headers, json=json_data
             ) as r:
-                _LOGGER.debug("Response from %s: %s", url, r.status)
+                _LOGGER.debug("Response from %s [%s]: %s", url, r.status, r.text)
 
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
                     except JSONDecodeError as e:
-                        _LOGGER.error(
+                        _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
@@ -719,7 +723,7 @@ class Bring:
                             "Sending notification failed due to authorization failure but "
                             "error response could not be parsed."
                         ) from e
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot send notification: %s",
                         errmsg["message"],
                     )
@@ -731,7 +735,7 @@ class Bring:
                 r.raise_for_status()
                 return r
         except asyncio.TimeoutError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot send notification %s for list %s:\n%s",
                 notification_type,
                 list_uuid,
@@ -742,7 +746,7 @@ class Bring:
                 "failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot send notification %s for list %s:\n%s",
                 notification_type,
                 list_uuid,
@@ -786,16 +790,15 @@ class Bring:
         try:
             url = f"{self.url}bringusers"
             async with self._session.get(url, headers=self.headers, params=params) as r:
-                _LOGGER.debug("Response from %s: %s", url, r.status)
+                _LOGGER.debug("Response from %s [%s]: %s", url, r.status, r.text)
 
                 if r.status == HTTPStatus.NOT_FOUND:
-                    _LOGGER.error("Exception: User %s does not exist.", mail)
                     raise BringUserUnknownException(f"User {mail} does not exist.")
 
                 r.raise_for_status()
 
         except asyncio.TimeoutError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot get verification for %s:\n%s",
                 mail,
                 traceback.format_exc(),
@@ -804,10 +807,6 @@ class Bring:
                 "Verifying email failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
-            _LOGGER.error(
-                "Exception: E-mail %s is invalid.",
-                mail,
-            )
             raise BringEMailInvalidException(f"E-mail {mail} is invalid.") from e
 
         return True
@@ -870,13 +869,13 @@ class Bring:
             try:
                 url = f"{LOCALES_BASE_URL}articles.{locale}.json"
                 async with self._session.get(url) as r:
-                    _LOGGER.debug("Response from %s: %s", url, r.status)
+                    _LOGGER.debug("Response from %s [%s]: %s", url, r.status, r.text)
                     r.raise_for_status()
 
                     try:
                         dictionaries[locale] = await r.json()
                     except JSONDecodeError as e:
-                        _LOGGER.error(
+                        _LOGGER.debug(
                             "Exception: Cannot load articles.%s.json:\n%s",
                             locale,
                             traceback.format_exc(),
@@ -886,7 +885,7 @@ class Bring:
                             "failed during parsing of request response."
                         ) from e
             except asyncio.TimeoutError as e:
-                _LOGGER.error(
+                _LOGGER.debug(
                     "Exception: Cannot load articles.%s.json::\n%s",
                     locale,
                     traceback.format_exc(),
@@ -897,7 +896,7 @@ class Bring:
                 ) from e
 
             except aiohttp.ClientError as e:
-                _LOGGER.error(
+                _LOGGER.debug(
                     "Exception: Cannot load articles.%s.json:\n%s",
                     locale,
                     traceback.format_exc(),
@@ -960,7 +959,7 @@ class Bring:
             )
 
         except Exception as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot load translation dictionary:\n%s",
                 traceback.format_exc(),
             )
@@ -994,7 +993,7 @@ class Bring:
             }
 
         except Exception as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot load user list settings:\n%s",
                 traceback.format_exc(),
             )
@@ -1022,13 +1021,13 @@ class Bring:
         try:
             url = f"{self.url}bringusersettings/{self.uuid}"
             async with self._session.get(url, headers=self.headers) as r:
-                _LOGGER.debug("Response from %s: %s", url, r.status)
+                _LOGGER.debug("Response from %s [%s]: %s", url, r.status, r.text)
 
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
                     except JSONDecodeError as e:
-                        _LOGGER.error(
+                        _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
@@ -1036,7 +1035,7 @@ class Bring:
                             "Loading user settings failed due to authorization failure but "
                             "error response could not be parsed."
                         ) from e
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot get user settings: %s",
                         errmsg["message"],
                     )
@@ -1097,7 +1096,7 @@ class Bring:
                     return data
 
                 except JSONDecodeError as e:
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot get user settings for uuid %s:\n%s",
                         self.uuid,
                         traceback.format_exc(),
@@ -1106,7 +1105,7 @@ class Bring:
                         "Loading user settings failed during parsing of request response."
                     ) from e
         except asyncio.TimeoutError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot get user settings for uuid %s:\n%s",
                 self.uuid,
                 traceback.format_exc(),
@@ -1115,7 +1114,7 @@ class Bring:
                 "Loading user settings failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot get user settings for uuid %s:\n%s",
                 self.uuid,
                 traceback.format_exc(),
@@ -1195,13 +1194,13 @@ class Bring:
         try:
             url = f"{self.url}v2/bringusers/{self.uuid}"
             async with self._session.get(url, headers=self.headers) as r:
-                _LOGGER.debug("Response from %s: %s", url, r.status)
+                _LOGGER.debug("Response from %s [%s]: %s", url, r.status, r.text)
 
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
                     except JSONDecodeError as e:
-                        _LOGGER.error(
+                        _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
@@ -1209,7 +1208,7 @@ class Bring:
                             "Loading current user settings failed due to authorization failure but "
                             "error response could not be parsed."
                         ) from e
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot get current user settings: %s",
                         errmsg["message"],
                     )
@@ -1231,14 +1230,14 @@ class Bring:
                     )
                     return data
                 except JSONDecodeError as e:
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot get lists:\n %s", traceback.format_exc()
                     )
                     raise BringParseException(
                         "Loading lists failed during parsing of request response."
                     ) from e
         except asyncio.TimeoutError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot get current user settings:\n %s",
                 traceback.format_exc(),
             )
@@ -1246,7 +1245,7 @@ class Bring:
                 "Loading current user settings failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot  current user settings:\n %s", traceback.format_exc()
             )
             raise BringRequestException(
@@ -1316,13 +1315,13 @@ class Bring:
             async with self._session.put(
                 url, headers=self.headers, json=json_data
             ) as r:
-                _LOGGER.debug("Response from %s: %s", url, r.status)
+                _LOGGER.debug("Response from %s [%s]: %s", url, r.status, r.text)
 
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
                     except JSONDecodeError as e:
-                        _LOGGER.error(
+                        _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
@@ -1330,7 +1329,7 @@ class Bring:
                             "Batch operation failed due to authorization failure but "
                             "error response could not be parsed."
                         ) from e
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot get execute batch operation: %s",
                         errmsg["message"],
                     )
@@ -1342,7 +1341,7 @@ class Bring:
                 r.raise_for_status()
                 return r
         except asyncio.TimeoutError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot execute batch operations for list %s:\n%s",
                 list_uuid,
                 traceback.format_exc(),
@@ -1351,7 +1350,7 @@ class Bring:
                 f"Batch operation for list {list_uuid} failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Exception: Cannot execute batch operations for %s:\n%s",
                 list_uuid,
                 traceback.format_exc(),
@@ -1389,12 +1388,12 @@ class Bring:
             async with self._session.post(
                 url, headers=self.headers, data=user_data
             ) as r:
-                _LOGGER.debug("Response from %s: %s", url, r.status)
+                _LOGGER.debug("Response from %s [%s]: %s", url, r.status, r.text)
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
                     except JSONDecodeError as e:
-                        _LOGGER.error(
+                        _LOGGER.debug(
                             "Exception: Cannot parse token request response:\n %s",
                             traceback.format_exc(),
                         )
@@ -1402,7 +1401,7 @@ class Bring:
                             "Retrieve new access token failed due to authorization failure but "
                             "error response could not be parsed."
                         ) from e
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot retrieve new access token: %s",
                         errmsg["message"],
                     )
@@ -1423,7 +1422,7 @@ class Bring:
                         },
                     )
                 except JSONDecodeError as e:
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Exception: Cannot retrieve new access token:\n %s",
                         traceback.format_exc(),
                     )
@@ -1431,12 +1430,12 @@ class Bring:
                         "Cannot parse token request response."
                     ) from e
         except asyncio.TimeoutError as e:
-            _LOGGER.error("Exception: Cannot login:\n %s", traceback.format_exc())
+            _LOGGER.debug("Exception: Cannot login:\n %s", traceback.format_exc())
             raise BringRequestException(
                 "Retrieve new access token failed due to connection timeout."
             ) from e
         except aiohttp.ClientError as e:
-            _LOGGER.error("Exception: Cannot login:\n %s", traceback.format_exc())
+            _LOGGER.debug("Exception: Cannot login:\n %s", traceback.format_exc())
             raise BringRequestException(
                 "Retrieve new access token failed due to request exception."
             ) from e

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bring-api
-version = 0.7.0
+version = 0.7.1
 author = Cyrill Raccaud
 author_email = cyrill.raccaud+pypi@gmail.com
 description = Unofficial package to access Bring! shopping lists API.


### PR DESCRIPTION
Changes all logging from error to debug were we already raise. This reduces the libraries chattiness a lot and does not fill the log files with stack traces on expected behavior.
Also debug messages for API requests now contain the raw server response, except requests for translation file downloads, as these would contain the complete bring website.