### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Set to scan for updates in the requirements files and dependecies of the Github actions.

Tested on my own fork and it instantly created 5 PRs for the Github actions. One of the github actions is failing because it is outdated and thought it might be better to let dependabot keep track of updating them.