### PR TITLE
Add project URLs to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,12 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
 
+[project.urls]
+Documentation = "https://miaucl.github.io/bring-api/"
+Source = "https://github.com/miaucl/bring-api"
+Issues = "https://github.com/miaucl/bring-api/issues"
+
+
 [options]
 packages = 
     bring_api


### PR DESCRIPTION
Updates  the `setup.cfg` file by adding the `[project.urls]` section. The following URLs have been included:

- Documentation: https://miaucl.github.io/bring-api/
- Source: https://github.com/miaucl/bring-api
- Issues: https://github.com/miaucl/bring-api/issues