### PR TITLE
Define name and photoPath as NotRequired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+# 0.7.3
+
+* Change `name` and `photoPath` in type definitions for `BringSyncCurrentUserResponse` and `BringAuthResponse` to optional parameters
+* Add py.typed file so that type checkers can use type annotations
+
 # 0.7.2
 
 * fix bug in debug log message.

--- a/bring_api/types.py
+++ b/bring_api/types.py
@@ -42,8 +42,8 @@ class BringAuthResponse(TypedDict):
     uuid: str
     publicUuid: str
     email: str
-    name: str
-    photoPath: str
+    name: NotRequired[str]
+    photoPath: NotRequired[str]
     bringListUUID: str
     access_token: str
     refresh_token: str
@@ -119,8 +119,8 @@ class BringSyncCurrentUserResponse(TypedDict):
 
     email: str
     emailVerified: bool
-    name: str
-    photoPath: str
+    name: NotRequired[str]
+    photoPath: NotRequired[str]
     premiumConfiguration: dict[str, bool]
     publicUserUuid: str
     userLocale: dict[str, str]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bring-api
-version = 0.7.2
+version = 0.7.3
 author = Cyrill Raccaud
 author_email = cyrill.raccaud+pypi@gmail.com
 description = Unofficial package to access Bring! shopping lists API.


### PR DESCRIPTION
Update type definitions `BringSyncCurrentUserResponse` and `BringAuthResponse` and set `name` and `photoPath` as optional attributes