### PR TITLE
Add py.typed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 .mypy_cache
 .env
 .coverage
+build/

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,5 +29,6 @@ install_requires =
 include_package_data = True
 
 [options.package_data]
+bring_api = py.typed
 bring_api.locales =
     *.json


### PR DESCRIPTION
Adds py.typed file so that type checkers like mypy know that this package provides type hints.