### PR TITLE
Reload locales after setting list language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# 0.8.1
+
+* Reload locales after setting list language to ensure all required article translations are available
+
 # 0.8.0
 
 * **New API method:** `set_list_article_language` sets the article language for a specified shopping list.

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -1557,6 +1557,7 @@ class Bring:
                     )
                 r.raise_for_status()
                 self.user_list_settings = await self.__load_user_list_settings()
+                self.__translations = await self.__load_article_translations()
                 return r
         except asyncio.TimeoutError as e:
             _LOGGER.debug(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bring-api
-version = 0.8.0
+version = 0.8.1
 author = Cyrill Raccaud
 author_email = cyrill.raccaud+pypi@gmail.com
 description = Unofficial package to access Bring! shopping lists API.

--- a/test.py
+++ b/test.py
@@ -231,6 +231,8 @@ async def main():
 
         await test_batch_list_operations(bring, lst)
 
+        await bring.set_list_article_language(lst["listUuid"], "es-ES")
+        await bring.get_list(lst["listUuid"])
         await bring.set_list_article_language(lst["listUuid"], "de-DE")
 
 


### PR DESCRIPTION
- ensure all required article translation tables are available during runtime