### PR TITLE
Improve publish workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -58,15 +58,6 @@ jobs:
             echo "Success: Tag version $TAG_VERSION found in package."
           fi
 
-      - name: Check tag in setup.cfg
-        run: |
-          if ! grep -q "version = $TAG_VERSION" setup.cfg; then
-            echo "Error: Tag version $TAG_VERSION not found in the setup.cfg."
-            exit 1
-          else
-            echo "Success: Tag version $TAG_VERSION found in setup.cfg."
-          fi
-
       - name: Check changelog entry
         run: |
           if [ github.ref =~ 'refs/tags/[0-9]+\\.[0-9]+\\.[0-9]+$' ]; then

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -49,6 +49,15 @@ jobs:
           TAG_VERSION=${GITHUB_REF#refs/tags/}
           echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
 
+      - name: Check tag in package
+        run: |
+          if ! grep -q "__VERSION__ = \"$TAG_VERSION\"" ./bring_api/__init__.py; then
+            echo "Error: Tag version $TAG_VERSION not found in the package."
+            exit 1
+          else
+            echo "Success: Tag version $TAG_VERSION found in package."
+          fi
+
       - name: Check tag in setup.cfg
         run: |
           if ! grep -q "version = $TAG_VERSION" setup.cfg; then

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Check tag in package
         run: |
-          if ! grep -q "__VERSION__ = \"$TAG_VERSION\"" ./bring_api/__init__.py; then
+          if ! grep -q "__version__ = \"$TAG_VERSION\"" ./bring_api/__init__.py; then
             echo "Error: Tag version $TAG_VERSION not found in the package."
             exit 1
           else

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,9 @@
 name: Publish Python 🐍 distribution 📦 to PyPI
 
-on: push
+on: 'push'
+
+env:
+  DEFAULT_PYTHON: "3.12"
 
 jobs:
   build:
@@ -12,7 +15,8 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.x"
+        python-version: ${{ env.DEFAULT_PYTHON }}
+        check-latest: true
     - name: Install pypa/build
       run: >-
         python3 -m
@@ -26,12 +30,79 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
+
+  check_version:
+    name: Check the version
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract tag version
+        id: extract_tag
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/}
+          echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
+
+      - name: Check tag in setup.cfg
+        run: |
+          if ! grep -q "version = $TAG_VERSION" setup.cfg; then
+            echo "Error: Tag version $TAG_VERSION not found in the setup.cfg."
+            exit 1
+          else
+            echo "Success: Tag version $TAG_VERSION found in setup.cfg."
+          fi
+
+      - name: Check changelog entry
+        run: |
+          if [ github.ref =~ 'refs/tags/[0-9]+\\.[0-9]+\\.[0-9]+$' ]; then
+            if ! grep -q "## $TAG_VERSION" CHANGELOG.md; then
+              echo "No changelog entry found for version $TAG_VERSION."
+              exit 1
+            else
+              echo "Changelog entry found for version $TAG_VERSION."
+            fi
+          else
+            echo "Pre-release tag, skipping changelog check"
+          fi
+
+      - name: Check if version type matches branch type
+        run: |
+          branch=$(git branch -r --contains ${{ github.ref }} --format "%(refname:lstrip=3)")
+          echo "Branch: $branch"
+          version=${GITHUB_REF#refs/tags/}
+          echo "Version from tag: $version"
+
+          # Check if the version is a prerelease
+          if [[ "$version" =~ [a-zA-Z] ]]; then
+            echo "Prerelease version detected: $version"
+            prerelease=true
+          else
+            echo "Final release version detected: $version"
+            prerelease=false
+          fi
+
+          # Fail if it's a prerelease and on the main branch
+          if [[ "$branch" == "main" && "$prerelease" == "true" ]]; then
+            echo "Error: Prerelease versions are not allowed on the main branch."
+            exit 1
+          fi
+
+          # Fail if it's a final release on a non-main branch
+          if [[ "$branch" != "main" && "$prerelease" == "false" ]]; then
+            echo "Error: Final releases are not allowed on non-main branches."
+            exit 1
+          fi
+
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
-    needs:
-    - build
+    needs: check_version
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -46,6 +117,7 @@ jobs:
         path: dist/
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+
   github-release:
     name: >-
       Sign the Python 🐍 distribution 📦 with Sigstore
@@ -59,6 +131,23 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for sigstore
 
     steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Get version
+      id: version
+      run: |
+        TAG_VERSION=${GITHUB_REF#refs/tags/}
+        echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
+    - name: Check if version is prerelease
+      id: check_prerelease
+      run: |
+        TAG_VERSION="${{ steps.version.outputs.version }}"
+        if [[ "$TAG_VERSION" =~ [a-zA-Z] ]]; then
+          echo "prerelease=true" >> $GITHUB_OUTPUT
+        else
+          echo "prerelease=false" >> $GITHUB_OUTPUT
+        fi
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
@@ -70,14 +159,15 @@ jobs:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
-    - name: Create GitHub Release
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ github.ref }}
+        name: ${{ steps.version.outputs.version }}
+        generate_release_notes: true
+        prerelease: ${{ steps.check_prerelease.outputs.prerelease }}  # Mark as prerelease if necessary
       env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        '${{ github.ref_name }}'
-        --repo '${{ github.repository }}'
-        --generate-notes
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -250,3 +250,9 @@ Following VSCode integrations may be helpful:
 - [ruff](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)
 - [mypy](https://marketplace.visualstudio.com/items?itemName=matangover.mypy)
 - [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
+
+### Releasing
+
+It is only possible to release a _final version_ on the `main` branch. For it to pass the gates of the `publish` workflow, it must have the same version in the `tag`, the `setup.cfg`, the `bring_api/__init__.py` and an entry in the `CHANGELOG.md` file.
+
+To release a prerelease version, no changelog entry is required, but it can only happen on a feature branch (**not** `main` branch). Also, prerelease versions are marked as such in the github release page.

--- a/bring_api/__init__.py
+++ b/bring_api/__init__.py
@@ -1,6 +1,6 @@
 """Bring API package."""
 
-__VERSION__ = "0.8.1a1"
+__version__ = "0.8.1a1"
 
 from .bring import Bring
 from .exceptions import (

--- a/bring_api/__init__.py
+++ b/bring_api/__init__.py
@@ -1,5 +1,7 @@
 """Bring API package."""
 
+__VERSION__ = "0.8.1a0"
+
 from .bring import Bring
 from .exceptions import (
     BringAuthException,

--- a/bring_api/__init__.py
+++ b/bring_api/__init__.py
@@ -1,6 +1,6 @@
 """Bring API package."""
 
-__VERSION__ = "0.8.1a0"
+__VERSION__ = "0.8.1a1"
 
 from .bring import Bring
 from .exceptions import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=46.4.0",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bring-api
-version = attr: package.__version__
+version = attr: bring_api.__version__
 author = Cyrill Raccaud
 author_email = cyrill.raccaud+pypi@gmail.com
 description = Unofficial package to access Bring! shopping lists API.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bring-api
-version = 0.8.1a0
+version = 0.8.1a1
 author = Cyrill Raccaud
 author_email = cyrill.raccaud+pypi@gmail.com
 description = Unofficial package to access Bring! shopping lists API.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bring-api
-version = 0.8.1a1
+version = attr: package.__version__
 author = Cyrill Raccaud
 author_email = cyrill.raccaud+pypi@gmail.com
 description = Unofficial package to access Bring! shopping lists API.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bring-api
-version = 0.8.1
+version = 0.8.1a0
 author = Cyrill Raccaud
 author_email = cyrill.raccaud+pypi@gmail.com
 description = Unofficial package to access Bring! shopping lists API.


### PR DESCRIPTION
Alignment of versioning and prereleases with pypi guidelines: https://pythonpackaging.info/07-Package-Release.html

- add gates for final and prerelease versions
- configure release according to version type
- verify tag version matches with setup and changelog
- add tag to package as `__VERSION__` export

It is only possible to release a final version on the `main` branch. For it to pass the gates, it must have the same version in the `tag`, the `setup.cfg`, the `bring_api/__init__.py` and an entry in the `CHANGELOG.md` file.

To release a prerelease version, no changelog entry is required, **but** it can only happen on a feature branch (**not** main branch). Also, prereleases are marked as such in the github release page.

See https://github.com/miaucl/bring-api/releases/tag/0.8.1a0 for an example of an alpha version testing the new publish workflow.