### PR TITLE
Upgrade deprecated syntax

### DIFF
--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -8,7 +8,7 @@ import logging
 import os
 import time
 import traceback
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 import aiohttp
 
@@ -157,7 +157,7 @@ class Bring:
                     raise BringParseException(
                         "Cannot parse login request response."
                     ) from e
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             _LOGGER.debug("Exception: Cannot login:\n %s", traceback.format_exc())
             raise BringRequestException(
                 "Authentication failed due to connection timeout."
@@ -250,7 +250,7 @@ class Bring:
                     raise BringParseException(
                         "Loading lists failed during parsing of request response."
                     ) from e
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             _LOGGER.debug("Exception: Cannot get lists:\n %s", traceback.format_exc())
             raise BringRequestException(
                 "Loading list failed due to connection timeout."
@@ -339,7 +339,7 @@ class Bring:
                     raise BringParseException(
                         "Loading list items failed during parsing of request response."
                     ) from e
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             _LOGGER.debug(
                 "Exception: Cannot get items for list %s:\n%s",
                 list_uuid,
@@ -439,7 +439,7 @@ class Bring:
                     raise BringParseException(
                         "Loading list details failed during parsing of request response."
                     ) from e
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             _LOGGER.debug(
                 "Exception: Cannot get item details for list %s:\n%s",
                 list_uuid,
@@ -761,7 +761,7 @@ class Bring:
 
                 r.raise_for_status()
                 return r
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             _LOGGER.debug(
                 "Exception: Cannot send notification %s for list %s:\n%s",
                 notification_type,
@@ -826,7 +826,7 @@ class Bring:
 
                 r.raise_for_status()
 
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             _LOGGER.debug(
                 "Exception: Cannot get verification for %s:\n%s",
                 mail,
@@ -928,7 +928,7 @@ class Bring:
                             f"Loading article translations for locale {locale} "
                             "failed during parsing of request response."
                         ) from e
-            except asyncio.TimeoutError as e:
+            except TimeoutError as e:
                 _LOGGER.debug(
                     "Exception: Cannot load articles.%s.json::\n%s",
                     locale,
@@ -1152,7 +1152,7 @@ class Bring:
                     raise BringParseException(
                         "Loading user settings failed during parsing of request response."
                     ) from e
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             _LOGGER.debug(
                 "Exception: Cannot get user settings for uuid %s:\n%s",
                 self.uuid,
@@ -1288,7 +1288,7 @@ class Bring:
                     raise BringParseException(
                         "Loading lists failed during parsing of request response."
                     ) from e
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             _LOGGER.debug(
                 "Exception: Cannot get current user settings:\n %s",
                 traceback.format_exc(),
@@ -1307,7 +1307,7 @@ class Bring:
     async def batch_update_list(
         self,
         list_uuid: str,
-        items: BringItem | List[BringItem] | list[dict[str, str]],
+        items: BringItem | list[BringItem] | list[dict[str, str]],
         operation: Optional[BringItemOperation] = None,
     ) -> aiohttp.ClientResponse:
         """Batch update items on a shopping list.
@@ -1398,7 +1398,7 @@ class Bring:
 
                 r.raise_for_status()
                 return r
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             _LOGGER.debug(
                 "Exception: Cannot execute batch operations for list %s:\n%s",
                 list_uuid,
@@ -1496,7 +1496,7 @@ class Bring:
                     raise BringParseException(
                         "Cannot parse token request response."
                     ) from e
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             _LOGGER.debug("Exception: Cannot login:\n %s", traceback.format_exc())
             raise BringRequestException(
                 "Retrieve new access token failed due to connection timeout."
@@ -1559,7 +1559,7 @@ class Bring:
                 self.user_list_settings = await self.__load_user_list_settings()
                 self.__translations = await self.__load_article_translations()
                 return r
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             _LOGGER.debug(
                 "Exception: Cannot set article language to %s for list %s:\n%s",
                 language,

--- a/bring_api/types.py
+++ b/bring_api/types.py
@@ -1,7 +1,7 @@
 """Bring API types."""
 
 from enum import Enum, StrEnum
-from typing import List, Literal, NotRequired, TypedDict
+from typing import Literal, NotRequired, TypedDict
 
 
 class BringList(TypedDict):
@@ -54,7 +54,7 @@ class BringAuthResponse(TypedDict):
 class BringListResponse(TypedDict):
     """A list response class."""
 
-    lists: List[BringList]
+    lists: list[BringList]
 
 
 class BringItemsResponse(TypedDict):
@@ -62,11 +62,11 @@ class BringItemsResponse(TypedDict):
 
     uuid: str
     status: str
-    purchase: List[BringPurchase]
-    recently: List[BringPurchase]
+    purchase: list[BringPurchase]
+    recently: list[BringPurchase]
 
 
-class BringListItemsDetailsResponse(List[BringListItemDetails]):
+class BringListItemsDetailsResponse(list[BringListItemDetails]):
     """A response class of a list of item details."""
 
 
@@ -88,7 +88,7 @@ class BringNotificationType(Enum):
 class BringNotificationsConfigType(TypedDict):
     """A notification config."""
 
-    arguments: List[str]
+    arguments: list[str]
     listNotificationType: str
     senderPublicUserUuid: str
 
@@ -104,14 +104,14 @@ class BringUserListSettingEntry(TypedDict):
     """A user list settings class. Represents a single list setting."""
 
     listUuid: str
-    usersettings: List[BringUserSettingsEntry]
+    usersettings: list[BringUserSettingsEntry]
 
 
 class BringUserSettingsResponse(TypedDict):
     """A user settings response class."""
 
-    usersettings: List[BringUserSettingsEntry]
-    userlistsettings: List[BringUserListSettingEntry]
+    usersettings: list[BringUserSettingsEntry]
+    userlistsettings: list[BringUserListSettingEntry]
 
 
 class BringSyncCurrentUserResponse(TypedDict):


### PR DESCRIPTION
Upgrade deprecated syntax

* Use alias `TimeoutError `instead of `asyncio.TimeoutError`
* Use `list` instead of `typing.List`

Preliminary PR for #80 