### PR TITLE
Use `X | Y` for type annotations

### DIFF
--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -8,7 +8,7 @@ import logging
 import os
 import time
 import traceback
-from typing import Optional, cast
+from typing import cast
 
 import aiohttp
 
@@ -672,7 +672,7 @@ class Bring:
         self,
         list_uuid: str,
         notification_type: BringNotificationType,
-        item_name: Optional[str] = None,
+        item_name: str | None = None,
     ) -> aiohttp.ClientResponse:
         """Send a push notification to all other members of a shared list.
 
@@ -776,7 +776,7 @@ class Bring:
                 "failed due to request exception."
             ) from e
 
-    async def does_user_exist(self, mail: Optional[str] = None) -> bool:
+    async def does_user_exist(self, mail: str | None = None) -> bool:
         """Check if e-mail is valid and user exists.
 
         Parameters
@@ -948,8 +948,8 @@ class Bring:
         self,
         item_id: str,
         *,
-        to_locale: Optional[str] = None,
-        from_locale: Optional[str] = None,
+        to_locale: str | None = None,
+        from_locale: str | None = None,
     ) -> str:
         """Translate a catalog item from or to a language.
 
@@ -1300,7 +1300,7 @@ class Bring:
         self,
         list_uuid: str,
         items: BringItem | list[BringItem] | list[dict[str, str]],
-        operation: Optional[BringItemOperation] = None,
+        operation: BringItemOperation | None = None,
     ) -> aiohttp.ClientResponse:
         """Batch update items on a shopping list.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,10 +95,6 @@ ignore = [
     "PLR0915", # Too many statements ({statements} > {max_statements})
     "PLR2004",  # Magic value used in comparison, consider replacing {value} with a constant variable
     "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
-    "UP006", # keep type annotation style as is
-    "UP007", # keep type annotation style as is
-    # Ignored due to performance: https://github.com/charliermarsh/ruff/issues/2923
-    "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
 
     # May conflict with the formatter, https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     "W191",


### PR DESCRIPTION
Unignore ruff UP007 rule and update type annotations to `X | Y` style instead of using `Optional`

Also unignore UP006 and UP038. No changes required as code already complies with these ruff rules