### PR TITLE
Add type hints for item attributes

### DIFF
--- a/bring_api/types.py
+++ b/bring_api/types.py
@@ -12,12 +12,20 @@ class BringList(TypedDict):
     theme: str
 
 
+class BringAttribute(TypedDict):
+    """An attribute class. Represents a single item attribute."""
+
+    type: str
+    content: dict[str, bool]
+
+
 class BringPurchase(TypedDict):
     """A purchase class. Represents a single item."""
 
     uuid: str
     itemId: str
     specification: str
+    attributes: list[BringAttribute]
 
 
 class BringListItemDetails(TypedDict):
@@ -142,8 +150,15 @@ class BringItem(TypedDict):
     spec: str
     uuid: str
     operation: NotRequired[
-        BringItemOperation | Literal["TO_PURCHASE", "TO_RECENTLY", "REMOVE"]
+        BringItemOperation
+        | Literal[
+            "TO_PURCHASE",
+            "TO_RECENTLY",
+            "REMOVE",
+            "ATTRIBUTE_UPDATE",
+        ]
     ]
+    attribute: NotRequired[BringAttribute]
 
 
 class BringAuthTokenResponse(TypedDict):


### PR DESCRIPTION
Adds type hints for newly added feature of attributes (If convenient, Offer, Urgent) in the Bring App

![image](https://github.com/user-attachments/assets/2235d1ed-6807-46ce-9242-6661258f7b5d)
