### PR TITLE
Let mypy enforce type annotations only in bring_api module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,10 @@ disallow_incomplete_defs = true
 disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
-disallow_untyped_defs = true
+disallow_untyped_defs = false
 warn_return_any = true
 warn_unreachable = true
+
+[[tool.mypy.overrides]]
+module = "bring_api"
+disallow_untyped_defs = true


### PR DESCRIPTION
Don't check for type annotations in tests