### PR TITLE
Pytest unit test config in pyproject.toml

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,4 +23,4 @@ jobs:
             pip install -r requirements.txt
             pip install -r requirements_test.txt
       - name: Test with pytest
-        run: pytest -v tests/ --cov=bring_api
+        run: pytest -v --cov-config=pyproject.toml --cov=bring_api

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,9 +21,9 @@
       }
     },
     {
-      "label": "Pytest",
+      "label": "Pytest: Unit tests",
       "type": "shell",
-      "command": "${command:python.interpreterPath} -m pytest tests/ --cov=bring_api -v --color=yes",
+      "command": "${command:python.interpreterPath} -m pytest --cov-config=pyproject.toml --cov=bring_api -v --color=yes",
       "problemMatcher": [],
       "group": {
         "kind": "test",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,9 +180,19 @@ max-complexity = 25
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = [
-    
     "tests",
 ]
+log_cli = true
+log_cli_level = "DEBUG"
+log_cli_format = "%(asctime)s%(msecs)03d [%(levelname)8s] %(name)s:%(lineno)s %(message)s"
+log_cli_date_format = "%Y%m%dT%H%M%S."
+
+[tool.coverage.run]
+branch = true
+source = ["tests"]
+
+[tool.coverage.report]
+format="text"
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
Move config to the `pyproject.toml` for unit testing with pytest.

Coverage config file needs explicit flag. The pytest already uses it but the paths were redundent in the config file and the command