### PR TITLE
add smoke test pr workflow

### DIFF
--- a/.github/workflows/smoke-test-pr.yaml
+++ b/.github/workflows/smoke-test-pr.yaml
@@ -14,11 +14,9 @@ concurrency:
 
 jobs:
   smoke_test_pr:
-
+    name: Smoke Test PR
     runs-on: ubuntu-latest
-
     if: ${{ github.event.label.name == 'run smoke test' }}
-
     steps:
       - name: Get User Permission
         id: checkAccess

--- a/.github/workflows/smoke-test-pr.yaml
+++ b/.github/workflows/smoke-test-pr.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Prepare empty headers
         run: touch .headers
       - name: Prepare headers with pytest
-        run: pytest smoke_test/test_1_setup_cookies.py -v -x
+        run: pytest smoke_test/test_1_setup_headers.py -v -x
         env:
           EMAIL: ${{ vars.EMAIL }}
           PASSWORD: ${{ secrets.PASSWORD }}

--- a/.github/workflows/smoke-test-pr.yaml
+++ b/.github/workflows/smoke-test-pr.yaml
@@ -1,0 +1,77 @@
+name: Smoke test (PR)
+
+on: 
+  pull_request_target:
+    types:
+      - labeled
+
+env:
+  python-version: "3.12"
+
+concurrency: 
+  group: "smoke-test" # Make sure, to not run multiple smoke tests at the same time
+  cancel-in-progress: false
+
+jobs:
+  smoke_test_pr:
+
+    runs-on: ubuntu-latest
+
+    if: ${{ github.event.label.name == 'run smoke test' }}
+
+    steps:
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: read
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+      - name: Checkout current code
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ env.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.python-version }}
+      - name: Check secret access
+        run: |
+          if [[ "x${{ secrets.PASSWORD }}" != "x" ]]; then
+            echo "Access to secrets"
+          else
+            echo "No access to secrets"
+            exit 1
+          fi
+      - run: pip install -r requirements.txt
+      - run: pip install -r requirements_test.txt
+      - name: Prepare empty headers
+        run: touch .headers
+      - name: Prepare headers with pytest
+        run: pytest smoke_test/test_1_setup_cookies.py -v -x
+        env:
+          EMAIL: ${{ vars.EMAIL }}
+          PASSWORD: ${{ secrets.PASSWORD }}
+          LIST: ${{ vars.LIST }}
+      # !!!!!!!!!!!!!!!!!!!!
+      # From here on, we run new code which does not have access to the password, only the headers
+      # !!!!!!!!!!!!!!!!!!!!
+      - name: Checkout new code
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
+          clean: false
+      - name: Test with pytest
+        run: pytest smoke_test/test_2_methods.py -v -x
+        env:
+          EMAIL: ${{ vars.EMAIL }}
+          PASSWORD: <redacted>
+          LIST: ${{ vars.LIST }}
+          
+          

--- a/.github/workflows/smoke-test-pr.yaml
+++ b/.github/workflows/smoke-test-pr.yaml
@@ -14,7 +14,6 @@ concurrency:
 
 jobs:
   smoke_test_pr:
-    name: Smoke Test PR
     runs-on: ubuntu-latest
     if: ${{ github.event.label.name == 'run smoke test' }}
     steps:

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -17,7 +17,6 @@ concurrency:
 
 jobs:
   smoke_test:
-    name: Smoke Test
     runs-on: ubuntu-latest
     steps:
       - name: Get User Permission

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   smoke_test:
+    name: Smoke Test
     runs-on: ubuntu-latest
     steps:
       - name: Get User Permission


### PR DESCRIPTION
Follow up to #93 with a workflow which should run even for forked PRs.

It uses `pull_request_target` to start with the `main` checked out and uses the access to the secrets to create a token. Afterwards, it checks out the new code and runs it.

This ensures, that in forks, the secrets are always used only by the code in the main branch before testing the new code.

This does not completely ward off all attacks to the password, which is why it is triggered only by `labeled` type, which means a reviewer first needs to validate the changes before adding the label `run smoke test` to effectively start the workflow.