### PR TITLE
Raise BringAuthException on parsing error for unauthorized requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,109 +1,113 @@
 # CHANGELOG
 
+## 0.9.1
+
+- Don't raise BringParseException on parsing errors for unauthorized request responses
+
 ## 0.9.0
 
-* Add type hints for item attributes (purchase conditions)
-* Minor code quality improvements, fix typos and upgrade type annotations
+- Add type hints for item attributes (purchase conditions)
+- Minor code quality improvements, fix typos and upgrade type annotations
 
 ## 0.8.1
 
-* Reload locales after setting list language to ensure all required article translations are available
+- Reload locales after setting list language to ensure all required article translations are available
 
 ## 0.8.0
 
-* **New API method:** `set_list_article_language` sets the article language for a specified shopping list.
+- **New API method:** `set_list_article_language` sets the article language for a specified shopping list.
 
 ## 0.7.3
 
-* Change `name` and `photoPath` in type definitions for `BringSyncCurrentUserResponse` and `BringAuthResponse` to optional parameters
-* Add py.typed file so that type checkers can use type annotations
+- Change `name` and `photoPath` in type definitions for `BringSyncCurrentUserResponse` and `BringAuthResponse` to optional parameters
+- Add py.typed file so that type checkers can use type annotations
 
 ## 0.7.2
 
-* fix bug in debug log message.
+- fix bug in debug log message.
 
 ## 0.7.1
 
-* Fix get_list method not returning uuid and status from JSON response
-* Log to debug instead of error where exceptions are already raised.
-* Add raw server response to debug log messages.
-* Update docstrings
+- Fix get_list method not returning uuid and status from JSON response
+- Log to debug instead of error where exceptions are already raised.
+- Add raw server response to debug log messages.
+- Update docstrings
 
 ## 0.7.0
 
-* **New API method:** `retrieve_new_access_token` retrieves a new access token and updates authorization headers. Time till expiration of the access token is stored in the property `expires_in` . ([tr4nt0r](https://github.com/tr4nt0r))
-* All API methods that require authentication now raise `BringAuthException` for 401 Unauthorized status ([tr4nt0r](https://github.com/tr4nt0r))
+- **New API method:** `retrieve_new_access_token` retrieves a new access token and updates authorization headers. Time till expiration of the access token is stored in the property `expires_in` . ([tr4nt0r](https://github.com/tr4nt0r))
+- All API methods that require authentication now raise `BringAuthException` for 401 Unauthorized status ([tr4nt0r](https://github.com/tr4nt0r))
 
 ## 0.6.0
 
-* **Pytest unit testing:** added pytest with full code coverage ([tr4nt0r](https://github.com/tr4nt0r))
-* **Github workflow for pytest:** added workflow for running pytests with Python 3.11 & 3.12 on Ubuntu, Windows and macOS ([tr4nt0r](https://github.com/tr4nt0r))
-* Update Python requirement to >=3.11
-* Change from implicit to explicit string conversion of `BringItemOperation` in JSON request payload ([tr4nt0r](https://github.com/tr4nt0r))
-* Change Type of `BringItemOperation` to `StrEnum` ([tr4nt0r](https://github.com/tr4nt0r))
-* `BringItem::operation` now also accepts string literals `TO_PURCHASE`, `TO_RECENTLY` & `REMOVE` ([tr4nt0r](https://github.com/tr4nt0r))
-* fix wrong variable name in `BringSyncCurrentUserResponse` class and add additional variables from JSON response ([tr4nt0r](https://github.com/tr4nt0r))
-* Improve exceptions for `save/update/remove/complete_item` and `batch_update_list` methods ([tr4nt0r](https://github.com/tr4nt0r))
-* Fix bug in `get_all_item_details` method ([tr4nt0r](https://github.com/tr4nt0r))
-* Parsing error when parsing unauthorized response now raises `BringParseException` ([tr4nt0r](https://github.com/tr4nt0r))
-* Cleanup legacy code ([tr4nt0r](https://github.com/tr4nt0r))
+- **Pytest unit testing:** added pytest with full code coverage ([tr4nt0r](https://github.com/tr4nt0r))
+- **Github workflow for pytest:** added workflow for running pytests with Python 3.11 & 3.12 on Ubuntu, Windows and macOS ([tr4nt0r](https://github.com/tr4nt0r))
+- Update Python requirement to >=3.11
+- Change from implicit to explicit string conversion of `BringItemOperation` in JSON request payload ([tr4nt0r](https://github.com/tr4nt0r))
+- Change Type of `BringItemOperation` to `StrEnum` ([tr4nt0r](https://github.com/tr4nt0r))
+- `BringItem::operation` now also accepts string literals `TO_PURCHASE`, `TO_RECENTLY` & `REMOVE` ([tr4nt0r](https://github.com/tr4nt0r))
+- fix wrong variable name in `BringSyncCurrentUserResponse` class and add additional variables from JSON response ([tr4nt0r](https://github.com/tr4nt0r))
+- Improve exceptions for `save/update/remove/complete_item` and `batch_update_list` methods ([tr4nt0r](https://github.com/tr4nt0r))
+- Fix bug in `get_all_item_details` method ([tr4nt0r](https://github.com/tr4nt0r))
+- Parsing error when parsing unauthorized response now raises `BringParseException` ([tr4nt0r](https://github.com/tr4nt0r))
+- Cleanup legacy code ([tr4nt0r](https://github.com/tr4nt0r))
 
 ## 0.5.7
 
-* **map user language to locales**: Bring sometimes stores non-standard locales in the user settings. In case the Bring API returns an invalid/unsupported locale, the user language is now mapped to a supported locale.
+- **map user language to locales**: Bring sometimes stores non-standard locales in the user settings. In case the Bring API returns an invalid/unsupported locale, the user language is now mapped to a supported locale.
 
 ## 0.5.6
 
-* fix incorrect filtering of locales against supported locales list
+- fix incorrect filtering of locales against supported locales list
 
 ## 0.5.5
 
-* Fix KeyError when listArticleLanguage is not set.
+- Fix KeyError when listArticleLanguage is not set.
   
 ## 0.5.4
 
-* Load article translations from file in executor instead of event loop.
+- Load article translations from file in executor instead of event loop.
 
 ## 0.5.3
 
-* Improve mypy type checking.
+- Improve mypy type checking.
   
 ## 0.5.2
 
-* Fixed build script to add locales explicitly.
+- Fixed build script to add locales explicitly.
 
 ## 0.5.1
 
-* Add article translation tables to package. Translation tables are now loaded from file as data from web app is outdated.
+- Add article translation tables to package. Translation tables are now loaded from file as data from web app is outdated.
 
 ## 0.5.0
 
-* **New API method:** `batch_update_list`. Uses the same API endpoint as the mobile app to add, complete and remove items from shopping lists and has support for uuid as unique identifier for list items.  
-* `save_item`, `update_item`, `complete_item` and `remove_item` are now wrapper methods for `batch_update_list` and have the additional parameter item_uuid.
+- **New API method:** `batch_update_list`. Uses the same API endpoint as the mobile app to add, complete and remove items from shopping lists and has support for uuid as unique identifier for list items.  
+- `save_item`, `update_item`, `complete_item` and `remove_item` are now wrapper methods for `batch_update_list` and have the additional parameter item_uuid.
 
 ## 0.4.1
 
-* instead of downloading all translation tables, required locales are determined from the user list settings and the user locale. ([tr4nt0r](https://github.com/tr4nt0r))
-* variable `userlistsettings` renamed to snake_cae `user_list_settings`. ([tr4nt0r](https://github.com/tr4nt0r))
+- instead of downloading all translation tables, required locales are determined from the user list settings and the user locale. ([tr4nt0r](https://github.com/tr4nt0r))
+- variable `userlistsettings` renamed to snake_cae `user_list_settings`. ([tr4nt0r](https://github.com/tr4nt0r))
 
 ## 0.4.0
 
-* **Localization support:** catalog items are now automatically translated based on the shopping lists language if configured, otherwise the users default language is used ([tr4nt0r](https://github.com/tr4nt0r))
-* **New API method:** `get_user_account`. Retrieves information about the current user like email, name and language ([tr4nt0r](https://github.com/tr4nt0r))
-* **New API method:** `get_all_user_settings`. Retrieves user settings like default list and individual list settings for section order and language ([tr4nt0r](https://github.com/tr4nt0r))
+- **Localization support:** catalog items are now automatically translated based on the shopping lists language if configured, otherwise the users default language is used ([tr4nt0r](https://github.com/tr4nt0r))
+- **New API method:** `get_user_account`. Retrieves information about the current user like email, name and language ([tr4nt0r](https://github.com/tr4nt0r))
+- **New API method:** `get_all_user_settings`. Retrieves user settings like default list and individual list settings for section order and language ([tr4nt0r](https://github.com/tr4nt0r))
 
 ## 0.3.1
 
-* Unpin requirements and remove subdependencies ([tr4nt0r](https://github.com/tr4nt0r))
+- Unpin requirements and remove subdependencies ([tr4nt0r](https://github.com/tr4nt0r))
 
 ## 0.3.0
 
-* Refactor for PEP8 compliance and code clean-up (breaking change) ([tr4nt0r](https://github.com/tr4nt0r))
+- Refactor for PEP8 compliance and code clean-up (breaking change) ([tr4nt0r](https://github.com/tr4nt0r))
 
 ## 0.2.0
 
-* Add new method does_user_exist ([tr4nt0r](https://github.com/tr4nt0r))
-* Fixes for test workflow
+- Add new method does_user_exist ([tr4nt0r](https://github.com/tr4nt0r))
+- Fixes for test workflow
 
 ## 0.1.4
 

--- a/bring_api/__init__.py
+++ b/bring_api/__init__.py
@@ -1,6 +1,6 @@
 """Bring API package."""
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 from .bring import Bring
 from .exceptions import (

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -120,16 +120,13 @@ class Bring:
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
-                    except JSONDecodeError as e:
+                    except (JSONDecodeError, aiohttp.ClientError):
                         _LOGGER.debug(
                             "Exception: Cannot parse login request response:\n %s",
                             traceback.format_exc(),
                         )
-                        raise BringParseException(
-                            "Login failed due to authorization failure "
-                            "but error response could not be parsed."
-                        ) from e
-                    _LOGGER.debug("Exception: Cannot login: %s", errmsg["message"])
+                    else:
+                        _LOGGER.debug("Exception: Cannot login: %s", errmsg["message"])
                     raise BringAuthException(
                         "Login failed due to authorization failure, "
                         "please check your email and password."
@@ -235,19 +232,15 @@ class Bring:
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
-                    except JSONDecodeError as e:
+                    except (JSONDecodeError, aiohttp.ClientError):
                         _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
-                        raise BringParseException(
-                            "Loading lists failed due to authorization failure but "
-                            "error response could not be parsed."
-                        ) from e
-                    _LOGGER.debug(
-                        "Exception: Cannot get lists: %s",
-                        errmsg["message"],
-                    )
+                    else:
+                        _LOGGER.debug(
+                            "Exception: Cannot get lists: %s", errmsg["message"]
+                        )
                     raise BringAuthException(
                         "Loading lists failed due to authorization failure, "
                         "the authorization token is invalid or expired."
@@ -317,19 +310,15 @@ class Bring:
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
-                    except JSONDecodeError as e:
+                    except (JSONDecodeError, aiohttp.ClientError):
                         _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
-                        raise BringParseException(
-                            "Loading list items failed due to authorization failure but "
-                            "error response could not be parsed."
-                        ) from e
-                    _LOGGER.debug(
-                        "Exception: Cannot get list items: %s",
-                        errmsg["message"],
-                    )
+                    else:
+                        _LOGGER.debug(
+                            "Exception: Cannot get list items: %s", errmsg["message"]
+                        )
                     raise BringAuthException(
                         "Loading list items failed due to authorization failure, "
                         "the authorization token is invalid or expired."
@@ -420,19 +409,15 @@ class Bring:
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
-                    except JSONDecodeError as e:
+                    except (JSONDecodeError, aiohttp.ClientError):
                         _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
-                        raise BringParseException(
-                            "Loading list details failed due to authorization failure but "
-                            "error response could not be parsed."
-                        ) from e
-                    _LOGGER.debug(
-                        "Exception: Cannot get list details: %s",
-                        errmsg["message"],
-                    )
+                    else:
+                        _LOGGER.debug(
+                            "Exception: Cannot get list details: %s", errmsg["message"]
+                        )
                     raise BringAuthException(
                         "Loading list details failed due to authorization failure, "
                         "the authorization token is invalid or expired."
@@ -756,19 +741,15 @@ class Bring:
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
-                    except JSONDecodeError as e:
+                    except (JSONDecodeError, aiohttp.ClientError):
                         _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
-                        raise BringParseException(
-                            "Sending notification failed due to authorization failure but "
-                            "error response could not be parsed."
-                        ) from e
-                    _LOGGER.debug(
-                        "Exception: Cannot send notification: %s",
-                        errmsg["message"],
-                    )
+                    else:
+                        _LOGGER.debug(
+                            "Exception: Cannot send notification: %s", errmsg["message"]
+                        )
                     raise BringAuthException(
                         "Sending notification failed due to authorization failure, "
                         "the authorization token is invalid or expired."
@@ -1089,19 +1070,15 @@ class Bring:
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
-                    except JSONDecodeError as e:
+                    except (JSONDecodeError, aiohttp.ClientError):
                         _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
-                        raise BringParseException(
-                            "Loading user settings failed due to authorization failure but "
-                            "error response could not be parsed."
-                        ) from e
-                    _LOGGER.debug(
-                        "Exception: Cannot get user settings: %s",
-                        errmsg["message"],
-                    )
+                    else:
+                        _LOGGER.debug(
+                            "Exception: Cannot get user settings: %s", errmsg["message"]
+                        )
                     raise BringAuthException(
                         "Loading user settings failed due to authorization failure, "
                         "the authorization token is invalid or expired."
@@ -1266,19 +1243,16 @@ class Bring:
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
-                    except JSONDecodeError as e:
+                    except (JSONDecodeError, aiohttp.ClientError):
                         _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
-                        raise BringParseException(
-                            "Loading current user settings failed due to authorization failure but "
-                            "error response could not be parsed."
-                        ) from e
-                    _LOGGER.debug(
-                        "Exception: Cannot get current user settings: %s",
-                        errmsg["message"],
-                    )
+                    else:
+                        _LOGGER.debug(
+                            "Exception: Cannot get current user settings: %s",
+                            errmsg["message"],
+                        )
                     raise BringAuthException(
                         "Loading current user settings failed due to authorization failure, "
                         "the authorization token is invalid or expired."
@@ -1394,19 +1368,16 @@ class Bring:
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
-                    except JSONDecodeError as e:
+                    except (JSONDecodeError, aiohttp.ClientError):
                         _LOGGER.debug(
                             "Exception: Cannot parse request response:\n %s",
                             traceback.format_exc(),
                         )
-                        raise BringParseException(
-                            "Batch operation failed due to authorization failure but "
-                            "error response could not be parsed."
-                        ) from e
-                    _LOGGER.debug(
-                        "Exception: Cannot get execute batch operation: %s",
-                        errmsg["message"],
-                    )
+                    else:
+                        _LOGGER.debug(
+                            "Exception: Cannot get execute batch operation: %s",
+                            errmsg["message"],
+                        )
                     raise BringAuthException(
                         "Batch operation failed due to authorization failure, "
                         "the authorization token is invalid or expired."
@@ -1475,19 +1446,16 @@ class Bring:
                 if r.status == HTTPStatus.UNAUTHORIZED:
                     try:
                         errmsg = await r.json()
-                    except JSONDecodeError as e:
+                    except (JSONDecodeError, aiohttp.ClientError):
                         _LOGGER.debug(
                             "Exception: Cannot parse token request response:\n %s",
                             traceback.format_exc(),
                         )
-                        raise BringParseException(
-                            "Retrieve new access token failed due to authorization failure but "
-                            "error response could not be parsed."
-                        ) from e
-                    _LOGGER.debug(
-                        "Exception: Cannot retrieve new access token: %s",
-                        errmsg["message"],
-                    )
+                    else:
+                        _LOGGER.debug(
+                            "Exception: Cannot retrieve new access token: %s",
+                            errmsg["message"],
+                        )
                     raise BringAuthException(
                         "Retrieve new access token failed due to authorization failure, "
                         "the refresh token is invalid or expired."

--- a/tests/test_bring.py
+++ b/tests/test_bring.py
@@ -147,8 +147,14 @@ class TestLogin:
         with pytest.raises(BringAuthException, match=expected):
             await bring.login()
 
-    @pytest.mark.parametrize("status", [HTTPStatus.OK, HTTPStatus.UNAUTHORIZED])
-    async def test_parse_exception(self, mocked, bring, status):
+    @pytest.mark.parametrize(
+        ("status", "exception"),
+        [
+            (HTTPStatus.OK, BringParseException),
+            (HTTPStatus.UNAUTHORIZED, BringAuthException),
+        ],
+    )
+    async def test_parse_exception(self, mocked, bring, status, exception):
         """Test parse exceptions."""
         mocked.post(
             "https://api.getbring.com/rest/v2/bringauth",
@@ -157,7 +163,7 @@ class TestLogin:
             content_type="application/json",
         )
 
-        with pytest.raises(BringParseException):
+        with pytest.raises(exception):
             await bring.login()
 
     @pytest.mark.parametrize(
@@ -230,8 +236,14 @@ class TestLoadLists:
 
         assert lists == BRING_LOAD_LISTS_RESPONSE
 
-    @pytest.mark.parametrize("status", [HTTPStatus.OK, HTTPStatus.UNAUTHORIZED])
-    async def test_parse_exception(self, mocked, bring, monkeypatch, status):
+    @pytest.mark.parametrize(
+        ("status", "exception"),
+        [
+            (HTTPStatus.OK, BringParseException),
+            (HTTPStatus.UNAUTHORIZED, BringAuthException),
+        ],
+    )
+    async def test_parse_exception(self, mocked, bring, monkeypatch, status, exception):
         """Test parse exceptions."""
         mocked.get(
             f"https://api.getbring.com/rest/bringusers/{UUID}/lists",
@@ -241,7 +253,7 @@ class TestLoadLists:
         )
         monkeypatch.setattr(bring, "uuid", UUID)
 
-        with pytest.raises(BringParseException):
+        with pytest.raises(exception):
             await bring.load_lists()
 
     async def test_unauthorized(self, mocked, bring, monkeypatch):
@@ -374,7 +386,7 @@ class TestNotifications:
             content_type="application/json",
         )
 
-        with pytest.raises(BringParseException):
+        with pytest.raises(BringAuthException):
             await bring.notify(UUID, BringNotificationType.GOING_SHOPPING)
 
 
@@ -409,8 +421,14 @@ class TestGetList:
         with pytest.raises(BringAuthException):
             await bring.get_list(UUID)
 
-    @pytest.mark.parametrize("status", [HTTPStatus.OK, HTTPStatus.UNAUTHORIZED])
-    async def test_parse_exception(self, mocked, bring, monkeypatch, status):
+    @pytest.mark.parametrize(
+        ("status", "exception"),
+        [
+            (HTTPStatus.OK, BringParseException),
+            (HTTPStatus.UNAUTHORIZED, BringAuthException),
+        ],
+    )
+    async def test_parse_exception(self, mocked, bring, monkeypatch, status, exception):
         """Test parse exceptions."""
         mocked.get(
             f"https://api.getbring.com/rest/v2/bringlists/{UUID}",
@@ -420,7 +438,7 @@ class TestGetList:
         )
         monkeypatch.setattr(bring, "uuid", UUID)
 
-        with pytest.raises(BringParseException):
+        with pytest.raises(exception):
             await bring.get_list(UUID)
 
     async def test_get_list(self, mocked, bring, monkeypatch):
@@ -478,8 +496,14 @@ class TestGetAllItemDetails:
         with pytest.raises(BringAuthException):
             await bring.get_all_item_details(UUID)
 
-    @pytest.mark.parametrize("status", [HTTPStatus.OK, HTTPStatus.UNAUTHORIZED])
-    async def test_parse_exception(self, mocked, bring, status):
+    @pytest.mark.parametrize(
+        ("status", "exception"),
+        [
+            (HTTPStatus.OK, BringParseException),
+            (HTTPStatus.UNAUTHORIZED, BringAuthException),
+        ],
+    )
+    async def test_parse_exception(self, mocked, bring, status, exception):
         """Test parse exceptions."""
         mocked.get(
             f"https://api.getbring.com/rest/bringlists/{UUID}/details",
@@ -488,7 +512,7 @@ class TestGetAllItemDetails:
             content_type="application/json",
         )
 
-        with pytest.raises(BringParseException):
+        with pytest.raises(exception):
             await bring.get_all_item_details(UUID)
 
     @pytest.mark.parametrize(
@@ -928,8 +952,14 @@ class TestGetUserAccount:
         with pytest.raises(BringAuthException):
             await bring.get_user_account()
 
-    @pytest.mark.parametrize("status", [HTTPStatus.OK, HTTPStatus.UNAUTHORIZED])
-    async def test_parse_exception(self, mocked, bring, monkeypatch, status):
+    @pytest.mark.parametrize(
+        ("status", "exception"),
+        [
+            (HTTPStatus.OK, BringParseException),
+            (HTTPStatus.UNAUTHORIZED, BringAuthException),
+        ],
+    )
+    async def test_parse_exception(self, mocked, bring, monkeypatch, status, exception):
         """Test parse exceptions."""
         mocked.get(
             f"https://api.getbring.com/rest/v2/bringusers/{UUID}",
@@ -939,7 +969,7 @@ class TestGetUserAccount:
         )
         monkeypatch.setattr(bring, "uuid", UUID)
 
-        with pytest.raises(BringParseException):
+        with pytest.raises(exception):
             await bring.get_user_account()
 
 
@@ -990,8 +1020,14 @@ class TestGetAllUserSettings:
         with pytest.raises(BringAuthException):
             await bring.get_all_user_settings()
 
-    @pytest.mark.parametrize("status", [HTTPStatus.OK, HTTPStatus.UNAUTHORIZED])
-    async def test_parse_exception(self, mocked, bring, monkeypatch, status):
+    @pytest.mark.parametrize(
+        ("status", "exception"),
+        [
+            (HTTPStatus.OK, BringParseException),
+            (HTTPStatus.UNAUTHORIZED, BringAuthException),
+        ],
+    )
+    async def test_parse_exception(self, mocked, bring, monkeypatch, status, exception):
         """Test parse exceptions."""
         mocked.get(
             f"https://api.getbring.com/rest/bringusersettings/{UUID}",
@@ -1001,7 +1037,7 @@ class TestGetAllUserSettings:
         )
         monkeypatch.setattr(bring, "uuid", UUID)
 
-        with pytest.raises(BringParseException):
+        with pytest.raises(exception):
             await bring.get_all_user_settings()
 
     async def test_load_user_list_settings(self, bring, monkeypatch):
@@ -1352,7 +1388,7 @@ class TestBatchUpdateList:
             content_type="application/json",
         )
 
-        with pytest.raises(BringParseException):
+        with pytest.raises(BringAuthException):
             await bring.batch_update_list(
                 UUID, BringItem(itemId="item_name", spec="spec", uuid=UUID)
             )
@@ -1406,8 +1442,14 @@ class TestRetrieveNewAccessToken:
         with pytest.raises(BringAuthException):
             await bring.retrieve_new_access_token()
 
-    @pytest.mark.parametrize("status", [HTTPStatus.OK, HTTPStatus.UNAUTHORIZED])
-    async def test_parse_exception(self, mocked, bring, status):
+    @pytest.mark.parametrize(
+        ("status", "exception"),
+        [
+            (HTTPStatus.OK, BringParseException),
+            (HTTPStatus.UNAUTHORIZED, BringAuthException),
+        ],
+    )
+    async def test_parse_exception(self, mocked, bring, status, exception):
         """Test request exceptions."""
 
         mocked.post(
@@ -1417,7 +1459,7 @@ class TestRetrieveNewAccessToken:
             content_type="application/json",
         )
 
-        with pytest.raises(BringParseException):
+        with pytest.raises(exception):
             await bring.retrieve_new_access_token()
 
 


### PR DESCRIPTION
Does not raise BringParseException anymore when parsing failed on an unauthorized request response, only log to debug