### PR TITLE
Fix tests github action to run also on pull requests

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,6 +1,6 @@
 name: Unit tests
 
-on: [push]
+on: [ push, pull_request ]
 
 jobs:
   unit_tests:


### PR DESCRIPTION
unit tests would run only on pushes to a branch on the main repo, but not on pull requests from a fork