### PR TITLE
Add common request method with token refresh handling and caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 site
 .headers
 .pytest_cache
+*.ipynb

--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -163,9 +163,11 @@ class Bring:
             ) from e
 
         if r.status == HTTPStatus.NOT_MODIFIED and etag:
-            _LOGGER.debug("Status NOT_MODIFIED, serving request from site cache")
+            _LOGGER.debug(
+                "ETag %s returned status 304, serving %s from site cache", etag, url
+            )
             try:
-                response = self._site_cache[etag]
+                return self._site_cache[etag]
             except KeyError:
                 self._etag.pop(str(url), None)
                 return await self._request(method, url, retry=True, **kwargs)

--- a/bring_api/types.py
+++ b/bring_api/types.py
@@ -3,11 +3,9 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
-from typing import Literal, NotRequired, TypedDict, TypeVar
+from typing import Literal, NotRequired, TypedDict
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
-
-BringResponse = TypeVar("BringResponse", bound=DataClassORJSONMixin)
 
 
 class ActivityType(StrEnum):

--- a/bring_api/types.py
+++ b/bring_api/types.py
@@ -3,9 +3,11 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
-from typing import Literal, NotRequired, TypedDict
+from typing import Literal, NotRequired, TypedDict, TypeVar
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+BringResponse = TypeVar("BringResponse", bound=DataClassORJSONMixin)
 
 
 class ActivityType(StrEnum):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ async def aiohttp_client_session() -> AsyncGenerator[aiohttp.ClientSession]:
 async def bring_api_client(session: aiohttp.ClientSession) -> Bring:
     """Create Bring instance."""
     bring = Bring(session, "EMAIL", "PASSWORD")
+    bring.expires_in = 604799
     return bring
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,8 @@ async def aiohttp_client_session() -> AsyncGenerator[aiohttp.ClientSession]:
 async def bring_api_client(session: aiohttp.ClientSession) -> Bring:
     """Create Bring instance."""
     bring = Bring(session, "EMAIL", "PASSWORD")
-    bring.expires_in = 604799
+    bring._expires_at = 604799
+
     return bring
 
 

--- a/tests/test_complete_item.py
+++ b/tests/test_complete_item.py
@@ -93,7 +93,6 @@ async def test_complete_item(
         f"https://api.getbring.com/rest/v2/bringlists/{UUID}/items",
         method="PUT",
         headers=DEFAULT_HEADERS,
-        data=None,
         json=payload,
     )
 

--- a/tests/test_get_activity.py
+++ b/tests/test_get_activity.py
@@ -1,21 +1,14 @@
 """Tests for get_activity method."""
 
-import asyncio
 from http import HTTPStatus
 
-import aiohttp
 from aioresponses import aioresponses
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from bring_api import (
-    Bring,
-    BringAuthException,
-    BringParseException,
-    BringRequestException,
-)
+from bring_api import Bring, BringAuthException, BringParseException
 
-from .conftest import UUID, load_fixture
+from .conftest import UUID
 
 
 @pytest.mark.usefixtures("mocked")
@@ -28,47 +21,6 @@ async def test_get_activity(
     activity = await bring.get_activity(UUID)
 
     assert activity == snapshot
-
-
-@pytest.mark.parametrize(
-    "exception",
-    [
-        asyncio.TimeoutError,
-        aiohttp.ClientError,
-    ],
-)
-async def test_request_exception(
-    mocked: aioresponses,
-    bring: Bring,
-    exception: type[Exception],
-) -> None:
-    """Test request exceptions."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/v2/bringlists/{UUID}/activity",
-        exception=exception,
-    )
-
-    with pytest.raises(BringRequestException):
-        await bring.get_activity(UUID)
-
-
-async def test_auth_exception(
-    mocked: aioresponses,
-    bring: Bring,
-) -> None:
-    """Test request exceptions."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/v2/bringlists/{UUID}/activity",
-        status=HTTPStatus.UNAUTHORIZED,
-        body=load_fixture("error_response.json"),
-    )
-
-    with pytest.raises(BringAuthException):
-        await bring.get_activity(UUID)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_get_all_item_details.py
+++ b/tests/test_get_all_item_details.py
@@ -1,9 +1,7 @@
 """Test for get_all_item_details method."""
 
-import asyncio
 from http import HTTPStatus
 
-import aiohttp
 from aioresponses import aioresponses
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -15,7 +13,7 @@ from bring_api import (
     BringRequestException,
 )
 
-from .conftest import UUID, load_fixture
+from .conftest import UUID
 
 
 @pytest.mark.usefixtures("mocked")
@@ -46,22 +44,6 @@ async def test_list_not_found(
         await bring.get_all_item_details(UUID)
 
 
-async def test_unauthorized(
-    mocked: aioresponses,
-    bring: Bring,
-) -> None:
-    """Test unauthorized exception."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/bringlists/{UUID}/details",
-        status=HTTPStatus.UNAUTHORIZED,
-        body=load_fixture("error_response.json"),
-    )
-    with pytest.raises(BringAuthException):
-        await bring.get_all_item_details(UUID)
-
-
 @pytest.mark.parametrize(
     ("status", "exception"),
     [
@@ -86,28 +68,4 @@ async def test_parse_exception(
     )
 
     with pytest.raises(exception):
-        await bring.get_all_item_details(UUID)
-
-
-@pytest.mark.parametrize(
-    "exception",
-    [
-        asyncio.TimeoutError,
-        aiohttp.ClientError,
-    ],
-)
-async def test_request_exception(
-    mocked: aioresponses,
-    bring: Bring,
-    exception: type[Exception],
-) -> None:
-    """Test request exceptions."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/bringlists/{UUID}/details",
-        exception=exception,
-    )
-
-    with pytest.raises(BringRequestException):
         await bring.get_all_item_details(UUID)

--- a/tests/test_get_all_user_settings.py
+++ b/tests/test_get_all_user_settings.py
@@ -1,10 +1,8 @@
 """Tests for get_all_user_settings method."""
 
-import asyncio
 from http import HTTPStatus
 from unittest.mock import patch
 
-import aiohttp
 from aioresponses import aioresponses
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -17,7 +15,7 @@ from bring_api import (
     BringTranslationException,
 )
 
-from .conftest import UUID, load_fixture
+from .conftest import UUID
 
 
 @pytest.mark.usefixtures("mocked")
@@ -30,47 +28,6 @@ async def test_get_all_user_settings(
     data = await bring.get_all_user_settings()
 
     assert data == snapshot
-
-
-@pytest.mark.parametrize(
-    "exception",
-    [
-        asyncio.TimeoutError,
-        aiohttp.ClientError,
-    ],
-)
-async def test_request_exception(
-    mocked: aioresponses,
-    bring: Bring,
-    exception: type[Exception],
-) -> None:
-    """Test request exceptions."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/bringusersettings/{UUID}",
-        exception=exception,
-    )
-
-    with pytest.raises(BringRequestException):
-        await bring.get_all_user_settings()
-
-
-async def test_unauthorized(
-    mocked: aioresponses,
-    bring: Bring,
-) -> None:
-    """Test unauthorized exception."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/bringusersettings/{UUID}",
-        status=HTTPStatus.UNAUTHORIZED,
-        body=load_fixture("error_response.json"),
-    )
-
-    with pytest.raises(BringAuthException):
-        await bring.get_all_user_settings()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_get_list.py
+++ b/tests/test_get_list.py
@@ -1,21 +1,14 @@
 """Tests for get_list method."""
 
-import asyncio
 from http import HTTPStatus
 
-import aiohttp
 from aioresponses import aioresponses
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from bring_api import (
-    Bring,
-    BringAuthException,
-    BringParseException,
-    BringRequestException,
-)
+from bring_api import Bring, BringAuthException, BringParseException
 
-from .conftest import UUID, load_fixture
+from .conftest import UUID
 
 
 @pytest.mark.usefixtures("mocked")
@@ -28,46 +21,6 @@ async def test_get_list(
 
     data = await bring.get_list(UUID)
     assert data == snapshot
-
-
-@pytest.mark.parametrize(
-    "exception",
-    [
-        asyncio.TimeoutError,
-        aiohttp.ClientError,
-    ],
-)
-async def test_request_exception(
-    mocked: aioresponses,
-    bring: Bring,
-    exception: type[Exception],
-) -> None:
-    """Test request exceptions."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/v2/bringlists/{UUID}",
-        exception=exception,
-    )
-
-    with pytest.raises(BringRequestException):
-        await bring.get_list(UUID)
-
-
-async def test_unauthorized(
-    mocked: aioresponses,
-    bring: Bring,
-) -> None:
-    """Test unauthorized exception."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/v2/bringlists/{UUID}",
-        status=HTTPStatus.UNAUTHORIZED,
-        body=load_fixture("error_response.json"),
-    )
-    with pytest.raises(BringAuthException):
-        await bring.get_list(UUID)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_get_list_users.py
+++ b/tests/test_get_list_users.py
@@ -1,21 +1,14 @@
 """Tests for get_list_users method."""
 
-import asyncio
 from http import HTTPStatus
 
-import aiohttp
 from aioresponses import aioresponses
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from bring_api import (
-    Bring,
-    BringAuthException,
-    BringParseException,
-    BringRequestException,
-)
+from bring_api import Bring, BringAuthException, BringParseException
 
-from .conftest import UUID, load_fixture
+from .conftest import UUID
 
 
 @pytest.mark.usefixtures("mocked")
@@ -29,47 +22,6 @@ async def test_get_lists_users(
     activity = await bring.get_list_users(UUID)
 
     assert activity == snapshot
-
-
-@pytest.mark.parametrize(
-    "exception",
-    [
-        asyncio.TimeoutError,
-        aiohttp.ClientError,
-    ],
-)
-async def test_request_exception(
-    mocked: aioresponses,
-    bring: Bring,
-    exception: type[Exception],
-) -> None:
-    """Test request exceptions."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/v2/bringlists/{UUID}/users",
-        exception=exception,
-    )
-
-    with pytest.raises(BringRequestException):
-        await bring.get_list_users(UUID)
-
-
-async def test_auth_exception(
-    mocked: aioresponses,
-    bring: Bring,
-) -> None:
-    """Test request exceptions."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/v2/bringlists/{UUID}/users",
-        status=HTTPStatus.UNAUTHORIZED,
-        body=load_fixture("error_response.json"),
-    )
-
-    with pytest.raises(BringAuthException):
-        await bring.get_list_users(UUID)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_get_user_account.py
+++ b/tests/test_get_user_account.py
@@ -1,21 +1,14 @@
 """Tests for get_user_account method."""
 
-import asyncio
 from http import HTTPStatus
 
-import aiohttp
 from aioresponses import aioresponses
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from bring_api import (
-    Bring,
-    BringAuthException,
-    BringParseException,
-    BringRequestException,
-)
+from bring_api import Bring, BringAuthException, BringParseException
 
-from .conftest import UUID, load_fixture
+from .conftest import UUID
 
 
 @pytest.mark.usefixtures("mocked")
@@ -28,47 +21,6 @@ async def test_get_user_account(
     data = await bring.get_user_account()
 
     assert data == snapshot
-
-
-@pytest.mark.parametrize(
-    "exception",
-    [
-        asyncio.TimeoutError,
-        aiohttp.ClientError,
-    ],
-)
-async def test_request_exception(
-    mocked: aioresponses,
-    bring: Bring,
-    exception: type[Exception],
-) -> None:
-    """Test request exceptions."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/v2/bringusers/{UUID}",
-        exception=exception,
-    )
-
-    with pytest.raises(BringRequestException):
-        await bring.get_user_account()
-
-
-async def test_unauthorized(
-    mocked: aioresponses,
-    bring: Bring,
-) -> None:
-    """Test unauthorized exception."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/v2/bringusers/{UUID}",
-        status=HTTPStatus.UNAUTHORIZED,
-        body=load_fixture("error_response.json"),
-    )
-
-    with pytest.raises(BringAuthException):
-        await bring.get_user_account()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_load_lists.py
+++ b/tests/test_load_lists.py
@@ -1,21 +1,14 @@
 """Tests for load_lists method."""
 
-import asyncio
 from http import HTTPStatus
 
-import aiohttp
 from aioresponses import aioresponses
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from bring_api import (
-    Bring,
-    BringAuthException,
-    BringParseException,
-    BringRequestException,
-)
+from bring_api import Bring, BringAuthException, BringParseException
 
-from .conftest import UUID, load_fixture
+from .conftest import UUID
 
 
 @pytest.mark.usefixtures("mocked")
@@ -54,45 +47,4 @@ async def test_parse_exception(
     )
 
     with pytest.raises(exception):
-        await bring.load_lists()
-
-
-async def test_unauthorized(
-    mocked: aioresponses,
-    bring: Bring,
-) -> None:
-    """Test unauthorized exception."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/bringusers/{UUID}/lists",
-        status=HTTPStatus.UNAUTHORIZED,
-        body=load_fixture("error_response.json"),
-    )
-
-    with pytest.raises(BringAuthException):
-        await bring.load_lists()
-
-
-@pytest.mark.parametrize(
-    "exception",
-    [
-        asyncio.TimeoutError,
-        aiohttp.ClientError,
-    ],
-)
-async def test_request_exception(
-    mocked: aioresponses,
-    bring: Bring,
-    exception: type[Exception],
-) -> None:
-    """Test request exceptions."""
-    await bring.login()
-    mocked.clear()
-    mocked.get(
-        f"https://api.getbring.com/rest/bringusers/{UUID}/lists",
-        exception=exception,
-    )
-
-    with pytest.raises(BringRequestException):
         await bring.load_lists()

--- a/tests/test_remove_item.py
+++ b/tests/test_remove_item.py
@@ -70,7 +70,6 @@ async def test_remove_item(
         f"https://api.getbring.com/rest/v2/bringlists/{UUID}/items",
         method="PUT",
         headers=DEFAULT_HEADERS,
-        data=None,
         json=payload,
     )
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,0 +1,90 @@
+"""Tests for request method."""
+
+import asyncio
+from http import HTTPStatus
+
+import aiohttp
+from aioresponses import aioresponses
+import pytest
+from yarl import URL
+
+from bring_api import Bring, BringAuthException, BringRequestException
+
+from .conftest import DEFAULT_HEADERS, load_fixture
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        asyncio.TimeoutError,
+        aiohttp.ClientError,
+    ],
+)
+async def test_request_exception(
+    mocked: aioresponses,
+    bring: Bring,
+    exception: type[Exception],
+) -> None:
+    """Test request exceptions."""
+    await bring.login()
+    mocked.get(
+        URL("https://api.getbring.com"),
+        exception=exception,
+    )
+
+    with pytest.raises(BringRequestException):
+        await bring._request("get", URL("https://api.getbring.com"))
+
+
+async def test_auth_exception(
+    mocked: aioresponses,
+    bring: Bring,
+) -> None:
+    """Test request exceptions."""
+    await bring.login()
+    mocked.clear()
+    mocked.post(
+        "https://api.getbring.com/rest/v2/bringauth/token",
+        status=HTTPStatus.UNAUTHORIZED,
+        body=load_fixture("error_response.json"),
+        repeat=True,
+    )
+    mocked.get(
+        URL("https://api.getbring.com"),
+        status=HTTPStatus.UNAUTHORIZED,
+        body=load_fixture("error_response.json"),
+        repeat=True,
+    )
+
+    with pytest.raises(BringAuthException):
+        await bring._request("get", URL("https://api.getbring.com"))
+
+
+async def test_auth_expired(
+    mocked: aioresponses,
+    bring: Bring,
+) -> None:
+    """Test refresh token before api request."""
+    await bring.login()
+    mocked.clear()
+    bring._expires_at = 0
+
+    mocked.post(
+        "https://api.getbring.com/rest/v2/bringauth/token",
+        status=HTTPStatus.OK,
+        body=load_fixture("token_response.json"),
+        repeat=True,
+    )
+    mocked.get(
+        URL("https://api.getbring.com/test"),
+        status=HTTPStatus.OK,
+        repeat=True,
+    )
+
+    await bring._request("GET", URL("https://api.getbring.com/test"))
+
+    mocked.assert_called_with(
+        "https://api.getbring.com/test",
+        method="get",
+        headers=DEFAULT_HEADERS,
+    )

--- a/tests/test_retrieve_new_access_token.py
+++ b/tests/test_retrieve_new_access_token.py
@@ -32,7 +32,7 @@ async def test_retrieve_new_access_token(
 
         assert data == snapshot
         assert bring.headers["Authorization"] == "Bearer {access_token}"
-        assert bring.expires_in == 604799
+        assert bring._expires_at == 604799
 
 
 @pytest.mark.parametrize(

--- a/tests/test_save_item.py
+++ b/tests/test_save_item.py
@@ -93,7 +93,6 @@ async def test_save_item(
         f"https://api.getbring.com/rest/v2/bringlists/{UUID}/items",
         method="PUT",
         headers=DEFAULT_HEADERS,
-        data=None,
         json=payload,
     )
 

--- a/tests/test_set_list_article_language.py
+++ b/tests/test_set_list_article_language.py
@@ -1,66 +1,27 @@
 """Tests for set_list_article_language method."""
 
-import asyncio
-from http import HTTPStatus
-
-import aiohttp
 from aioresponses import aioresponses
 import pytest
 
-from bring_api import Bring, BringAuthException, BringRequestException
+from bring_api import Bring
 
-from .conftest import UUID
+from .conftest import DEFAULT_HEADERS, UUID
 
 
-@pytest.mark.usefixtures("mocked")
 async def test_set_list_article_language(
+    mocked: aioresponses,
     bring: Bring,
 ) -> None:
     """Test set list article language."""
     await bring.login()
 
-    resp = await bring.set_list_article_language(UUID, "de-DE")
-    assert resp.status == HTTPStatus.OK
-
-
-@pytest.mark.parametrize(
-    "exception",
-    [
-        asyncio.TimeoutError,
-        aiohttp.ClientError,
-    ],
-)
-async def test_request_exception(
-    mocked: aioresponses,
-    bring: Bring,
-    exception: type[Exception],
-) -> None:
-    """Test request exceptions."""
-    await bring.login()
-    mocked.clear()
-    mocked.post(
+    await bring.set_list_article_language(UUID, "de-DE")
+    mocked.assert_called_with(
         f"https://api.getbring.com/rest/bringusersettings/{UUID}/{UUID}/listArticleLanguage",
-        exception=exception,
+        method="POST",
+        headers=DEFAULT_HEADERS,
+        data={"value": "de-DE"},
     )
-
-    with pytest.raises(BringRequestException):
-        await bring.set_list_article_language(UUID, "de-DE")
-
-
-async def test_unauthorized(
-    mocked: aioresponses,
-    bring: Bring,
-) -> None:
-    """Test unauthorized exception."""
-    await bring.login()
-    mocked.clear()
-    mocked.post(
-        f"https://api.getbring.com/rest/bringusersettings/{UUID}/{UUID}/listArticleLanguage",
-        status=HTTPStatus.UNAUTHORIZED,
-    )
-
-    with pytest.raises(BringAuthException):
-        await bring.set_list_article_language(UUID, "de-DE")
 
 
 async def test_value_error(

--- a/tests/test_update_item.py
+++ b/tests/test_update_item.py
@@ -94,7 +94,6 @@ async def test_update_item(
         f"https://api.getbring.com/rest/v2/bringlists/{UUID}/items",
         method="PUT",
         headers=DEFAULT_HEADERS,
-        data=None,
         json=payload,
     )
 


### PR DESCRIPTION
Adds a request method to be used by other API methods. 
- Reduces duplicate code for exception handling, but exception messages have to be more generic
- Ensures the access token is valid. 
  - If token is expired, the token will be refreshed before the actual request
  - If token is not expired it continues with the request
  - If the request fails with an authentication exception, is refreshed and the request retried
  - If we don't have a valid refresh token the token refresh method will raise an auth exception
- Support for cache headers
  - Responses that contain an etag will be cached in a dict for later re-use
  - When sending a request for an endpoint were an etag is available from a previous request, it will be sent in the headers
  - If the endpoint responds with a not modified status the response will be served from the cache
  - if the endpoint returns with a Ok status and contains en etag, the cache is updated before serving the response 
  - If the API returns a not modified status but there is nothing cached, the request is retried without cache headers.

~Currently only the load_lists method has been refactored to use the method. If this change is approved, I will proceed with the refactoring.~ 