### PR TITLE
Add GitHub workflows for release drafting and labeling

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,86 @@
+---
+# Labels names are important as they are used by Release Drafter to decide
+# regarding where to record them in changelog or if to skip them.
+#
+# The repository labels will be automatically configured using this file and
+# the GitHub Action https://github.com/marketplace/actions/github-labeler.
+- name: ':boom: breaking change'
+  from_name: breaking
+  description: Breaking Changes
+  color: bfd4f2
+- name: ':ghost: bug'
+  from_name: bug
+  description: Something isn't working
+  color: d73a4a
+- name: ':building_construction: build'
+  from_name: build
+  description: Build System and Dependencies
+  color: bfdadc
+- name: ':construction_worker_woman: ci'
+  from_name: ci
+  description: Continuous Integration
+  color: 4a97d6
+- name: ':recycle: dependencies'
+  from_name: dependencies
+  description: Pull requests that update a dependency file
+  color: 0366d6
+- name: ':book: documentation'
+  from_name: documentation
+  description: Improvements or additions to documentation
+  color: 0075ca
+- name: ':roll_eyes: duplicate'
+  from_name: duplicate
+  description: This issue or pull request already exists
+  color: cfd3d7
+- name: ':rocket: feature'
+  from_name: enhancement
+  description: New feature or request
+  color: a2eeef
+- name: ':clapper: github_actions'
+  from_name: github_actions
+  description: Pull requests that update Github_actions code
+  color: '000000'
+- name: ':hatching_chick: good first issue'
+  from_name: good first issue
+  description: Good for newcomers
+  color: 7057ff
+- name: ':pray: help wanted'
+  from_name: help wanted
+  description: Extra attention is needed
+  color: '008672'
+- name: ':no_entry_sign: invalid'
+  from_name: invalid
+  description: This doesn't seem right
+  color: e4e669
+- name: ':racing_car: performance'
+  from_name: performance
+  description: Performance
+  color: '016175'
+- name: ':snake: python'
+  from_name: python
+  description: Pull requests that update Python code
+  color: 2b67c6
+- name: ':question: question'
+  from_name: question
+  description: Further information is requested
+  color: d876e3
+- name: ':sparkles: code quality'
+  from_name: code quality
+  description: Code quality improvements
+  color: ef67c4
+- name: ':file_cabinet: deprecation'
+  from_name: deprecation
+  description: Removals and Deprecations
+  color: 9ae7ea
+- name: ':nail_care: style'
+  from_name: style
+  description: Style
+  color: c120e5
+- name: ':test_tube: testing'
+  from_name: testing
+  description: Pull request that adds tests
+  color: b1fc6f
+- name: ':woman_shrugging: wontfix'
+  from_name: wontfix
+  description: This will not be worked on
+  color: ffffff

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,86 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+
+
+categories:
+  - title: '💥 Breaking changes'
+    labels:
+      - ':boom: breaking change'
+  - title: '🚀 New Features'
+    labels:
+      - ':rocket: feature'
+  - title: '👻 Bug Fixes'
+    labels:
+      - ':ghost: bug'
+  - title: '🗄️ Deprecations'
+    labels:
+      - ':file_cabinet: deprecation'
+  - title: '📃 Documentation'
+    labels:
+      - ':book: documentation'
+  - title: '🧰 Maintenance'
+    labels:
+      - ':building_construction: build'
+      - ':construction_worker_woman: ci'
+      - ':clapper: github_actions'
+  - title: '🔬 Other updates'
+    labels:
+      - ':nail_care: style'
+      - ':test_tube: testing'
+      - ':racing_car: performance'
+      - ':sparkles: code quality'
+  - title: '🧩 Dependency Updates'
+    labels:
+      - ':recycle: dependencies'
+
+
+autolabeler:
+  - label: ':rocket: feature'
+    title:
+      - '/adds/i'
+      - '/add method/i'
+  - label: ':ghost: bug'
+    title:
+      - '/fix/i'
+  - label: ':sparkles: code quality'
+    title:
+      - '/Refactor/i'
+  - label: ':test_tube: testing'
+    files:
+      - 'test_*'
+      - 'conftest.py'
+  - label: ':book: documentation'
+    title:
+      - '/docs:/i'
+    files:
+      - '*.md'
+      - 'mkdocs.yml'
+  - label: ':construction_worker_woman: ci'
+    files:
+      - '.github/*'
+  - label: ':recycle: dependencies'
+    title:
+      - '/bump/i'
+  - label: ':file_cabinet: deprecation'
+    title:
+      - '/Deprecate/i'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+
+version-resolver:
+  major:
+    labels:
+      - 'breaking'
+  minor:
+    labels:
+      - 'feature'
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  Contributors: $CONTRIBUTORS

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,0 +1,17 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-draft:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,25 @@
+name: Labeler
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Run Labeler
+        uses: crazy-max/ghaction-github-labeler@v5.2.0
+        with:
+          skip-delete: true

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -162,9 +162,10 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v2
       with:
+        draft: true
         tag_name: ${{ github.ref }}
-        name: ${{ steps.version.outputs.version }}
-        generate_release_notes: true
+        # name: ${{ steps.version.outputs.version }}
+        # generate_release_notes: true
         prerelease: ${{ steps.check_prerelease.outputs.prerelease }}  # Mark as prerelease if necessary
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   


### PR DESCRIPTION
- This workflow generates a [fancy looking release notes](https://github.com/tr4nt0r/habiticalib/releases/tag/v0.3.4) as a draft when a new PR is merged and continuously adds subsequent merges to the draft. 
- The release note has various categories and and the changes are categorized based on the labels of the PRs. 
- There is also a feature that will automatically add labels to new PRs by looking for keywords or what files were changed, but that can be changed afterwards if the label doesn't fit. 
- This will also suggest the next version based on the previous release. If a breaking change was merged, the major version will be incremented, if a new feature was merged, the minor version, otherwise the patch version.
- Also fancy new labels will be created

Temporarily changed gh release action to not publish the release but instead do it manually as this will possibly need some fine tuning 