### PR TITLE
Add retry logic for bad gateway response errors

### DIFF
--- a/bring_api/bring.py
+++ b/bring_api/bring.py
@@ -7,6 +7,7 @@ import json
 from json import JSONDecodeError
 import logging
 import os
+from random import randint
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -143,6 +144,18 @@ class Bring:
                     "Request failed due to authorization failure, "
                     "the authorization token is invalid or expired."
                 )
+
+            if (
+                r.status
+                in (
+                    HTTPStatus.BAD_GATEWAY,
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    HTTPStatus.GATEWAY_TIMEOUT,
+                )
+                and not retry
+            ):
+                await asyncio.sleep(delay=randint(1, 5000) / 1000)
+                return await self._request(method, url, retry=True, **kwargs)
 
             r.raise_for_status()
 


### PR DESCRIPTION
Bring are using AWS Elastic Load Balancer to distribute the load to the Bring servers. Sporadically they respond with a 502 bad gateway error. My research for the cause of this error has shown that the cause may be a misconfiguration of their servers. The keep-alive of the API servers is shorter than the keep-alive of the load balancers, which is causing the load balancers not being able route the request because the connection was already closed. 
 See - https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2272#issuecomment-938428493

I can't fix that as it is outside of my control, but I can add a retry logic for this error.
The retry will be happen after 502, 503 and 504 status after waiting randomly for 1 ms to 5 s