### PR TITLE
Re-enable generated release notes only for prereleases

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -148,11 +148,11 @@ jobs:
           ./dist/*.whl
     - name: Release
       uses: softprops/action-gh-release@v2
+      if: ${{ steps.check_prerelease.outputs.prerelease }}
       with:
-        draft: true
         tag_name: ${{ github.ref }}
-        # name: ${{ steps.version.outputs.version }}
-        # generate_release_notes: true
+        name: ${{ steps.version.outputs.version }}
+        generate_release_notes: true
         prerelease: ${{ steps.check_prerelease.outputs.prerelease }}  # Mark as prerelease if necessary
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   


### PR DESCRIPTION
Release notes for final releases will continue to be created with release-drafter, release notes for prereleases will be created with githubs release notes generator