### PR TITLE
Add labels enhancement and skip-changelog to release-drafter

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -92,5 +92,5 @@
   description: Minor feature improvement
 - name: 'skip-changelog'
   color: D3D3D3
-  description: Ommits this PR in the changelog
+  description: Omits this PR in the changelog
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -84,3 +84,13 @@
   from_name: wontfix
   description: This will not be worked on
   color: ffffff
+- name: ':arrow_up: bump'
+  description: Bumps the version for a release
+  color: 3C5D34
+- name: ':sparkles: enhancement'
+  color: CBF8DA
+  description: Minor feature improvement
+- name: 'skip-changelog'
+  color: D3D3D3
+  description: Ommits this PR in the changelog
+

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,11 +29,13 @@ categories:
       - ':test_tube: testing'
       - ':racing_car: performance'
       - ':sparkles: code quality'
+      - ':sparkles: enhancement'
   - title: '🧩 Dependency Updates'
     labels:
       - ':recycle: dependencies'
 exclude-labels:
   - ':arrow_up: bump'
+  - 'skip-changelog'
 
 autolabeler:
   - label: ':rocket: feature'


### PR DESCRIPTION
- enhancement is for feature improvements that are too small to justify increasing the minor version.
- Bump already exists but was added manually
- skip-changelog will ommit PRs from the changelog, for example for reverted PRs