### PR TITLE
Use PEP639 compliant SPDX license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,9 @@ requires-python = ">=3.11"
 
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"
 ]
-license = {text = "MIT License"}
+license = "MIT"
 
 [tool.setuptools]
 packages = ["bring_api", "bring_api.locales"]


### PR DESCRIPTION
Update the license declaration to use a PEP639 compliant SPDX expression instead of the legacy format string and remove deprecated license classifiers