### PR TITLE
Fix typo in `types.py` docstring

### DIFF
--- a/bring_api/types.py
+++ b/bring_api/types.py
@@ -323,7 +323,7 @@ class BringActivityResponse(DataClassORJSONMixin):
 
 @dataclass(kw_only=True)
 class BringErrorResponse(DataClassORJSONMixin):
-    """Error resonse class."""
+    """Error response class."""
 
     message: str
     error: str


### PR DESCRIPTION
Typo in docstring for BringErrorResponse