### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -2,6 +2,9 @@ name: Markdownlint
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -2,6 +2,9 @@ name: Mypy
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 env:
   DEFAULT_PYTHON: "3.12"
 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,6 +2,9 @@ name: Publish Python 🐍 distribution 📦 to PyPI
 
 on: 'push'
 
+permissions:
+  contents: read
+
 env:
   DEFAULT_PYTHON: "3.12"
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -2,6 +2,9 @@ name: Ruff
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test-pr.yaml
+++ b/.github/workflows/smoke-test-pr.yaml
@@ -5,6 +5,9 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: read
+
 env:
   python-version: "3.12"
 

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '0 23 * * 0' # Run every Sunday at 23:00 PM
   workflow_dispatch: # Allows manual triggering
+
+permissions:
+  contents: read
     
 env:
   python-version: "3.12"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -2,6 +2,9 @@ name: Unit tests
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   unit_tests:
 


### PR DESCRIPTION
Potential fix for [https://github.com/miaucl/bring-api/security/code-scanning/5](https://github.com/miaucl/bring-api/security/code-scanning/5)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained regardless of repository/org defaults.

Best single fix here (without changing behavior beyond permission hardening): add a root-level permissions block with the minimal required baseline:
- `contents: read`

This should be inserted in `.github/workflows/smoke-test-pr.yaml` near the top-level keys (e.g., after `on:` and before `env:`), so it applies to all jobs in this workflow. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
