### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,6 +2,9 @@ name: Publish Python 🐍 distribution 📦 to PyPI
 
 on: 'push'
 
+permissions:
+  contents: read
+
 env:
   DEFAULT_PYTHON: "3.12"
 


### PR DESCRIPTION
Potential fix for [https://github.com/miaucl/bring-api/security/code-scanning/18](https://github.com/miaucl/bring-api/security/code-scanning/18)

Add a workflow-level `permissions` block so every job gets a safe default (`contents: read`), while keeping the existing job-level override for PyPI trusted publishing (`id-token: write`) unchanged.

Best single fix without changing functionality:
- Edit `.github/workflows/publish-to-pypi.yml`
- Insert at the top level (after `on:` is a clean location) a minimal explicit permissions block:
  - `permissions:`
  - `  contents: read`

Why this works:
- It resolves CodeQL for jobs like `build` and `check_version` that currently have no explicit permissions.
- It preserves existing behavior for `publish-to-pypi`, because that job already has its own `permissions` block and will continue to use `id-token: write` for trusted publishing.

No imports, methods, or additional definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
